### PR TITLE
Enable native/app address validation and conversion for wasm app (#102)

### DIFF
--- a/core/iwasm/lib/native-interface/wasm_export.h
+++ b/core/iwasm/lib/native-interface/wasm_export.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _WASM_EXPORT_H
+#define _WASM_EXPORT_H
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+/**
+ * API exported to WASM application
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Get current WASM module instance of the current native thread
+ *
+ * @return current WASM module instance of the current native thread, 0
+ *         if not found
+ * Note: the return type is uint64_t but not pointer type, because that
+ *       the we only supports WASM-32, in which the pointer type is
+ *       compiled to WASM i32 type, but the pointer type in native can be
+ *       32-bit and 64-bit. And if the native pointer is 64-bit, data loss
+ *       occurs after converting it to WASM i32 type.
+ */
+uint64_t
+wasm_runtime_get_current_module_inst();
+
+/**
+ * Validate the app address, check whether it belongs to WASM module
+ * instance's address space, or in its heap space or memory space.
+ *
+ * @param module_inst the WASM module instance
+ * @param app_offset the app address to validate, which is a relative address
+ * @param size the size bytes of the app address
+ *
+ * @return true if success, false otherwise.
+ */
+bool
+wasm_runtime_validate_app_addr(uint64_t module_inst,
+                               int32_t app_offset, uint32_t size);
+
+/**
+ * Validate the native address, check whether it belongs to WASM module
+ * instance's address space, or in its heap space or memory space.
+ *
+ * @param module_inst the WASM module instance
+ * @param native_ptr the native address to validate, which is an absolute
+ *        address
+ * @param size the size bytes of the app address
+ *
+ * @return true if success, false otherwise.
+ */
+bool
+wasm_runtime_validate_native_addr(uint64_t module_inst,
+                                  uint64_t native_ptr, uint32_t size);
+
+/**
+ * Convert app address(relative address) to native address(absolute address)
+ *
+ * @param module_inst the WASM module instance
+ * @param app_offset the app adress
+ *
+ * @return the native address converted
+ */
+uint64_t
+wasm_runtime_addr_app_to_native(uint64_t module_inst,
+                                int32_t app_offset);
+
+/**
+ * Convert native address(absolute address) to app address(relative address)
+ *
+ * @param module_inst the WASM module instance
+ * @param native_ptr the native address
+ *
+ * @return the app address converted
+ */
+int32_t
+wasm_runtime_addr_native_to_app(uint64_t module_inst,
+                                uint64_t native_ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* end of _WASM_EXPORT_H */

--- a/core/iwasm/lib/native/base/base_lib_export.c
+++ b/core/iwasm/lib/native/base/base_lib_export.c
@@ -18,10 +18,115 @@
 #include <stdlib.h>
 #include <string.h>
 #include "lib_export.h"
+#include "bh_platform.h"
+#include "wasm_export.h"
 
 #ifdef WASM_ENABLE_BASE_LIB
 #include "base_lib_export.h"
 #endif
+
+static uint64
+wasm_runtime_get_current_module_inst_wrapper()
+{
+    return (uint64)(uintptr_t)
+        wasm_runtime_get_current_module_inst();
+}
+
+static bool
+wasm_runtime_validate_app_addr_wrapper(uint32 inst_part0, uint32 inst_part1,
+                                       int32 app_offset, uint32 size)
+{
+    bool ret;
+    wasm_module_inst_t module_inst =
+        wasm_runtime_get_current_module_inst();
+    union { uint64 u64; uint32 parts[2]; } inst;
+
+    inst.parts[0] = inst_part0;
+    inst.parts[1] = inst_part1;
+
+    if (inst.u64 != (uint64)(uintptr_t)module_inst) {
+        printf("Invalid module instance\n");
+        return false;
+    }
+
+    ret = wasm_runtime_validate_app_addr(module_inst, app_offset, size);
+    if (!ret)
+        wasm_runtime_clear_exception(module_inst);
+    return ret;
+}
+
+static bool
+wasm_runtime_validate_native_addr_wrapper(uint32 inst_part0, uint32 inst_part1,
+                                          uint32 native_ptr_part0,
+                                          uint32 native_ptr_part1,
+                                          uint32 size)
+{
+    bool ret;
+    wasm_module_inst_t module_inst =
+        wasm_runtime_get_current_module_inst();
+    union { uint64 u64; uint32 parts[2]; } inst;
+    union { uint64 u64; uint32 parts[2]; } native_ptr;
+
+    inst.parts[0] = inst_part0;
+    inst.parts[1] = inst_part1;
+
+    if (inst.u64 != (uint64)(uintptr_t)module_inst) {
+        printf("Invalid module instance\n");
+        return false;
+    }
+
+    native_ptr.parts[0] = native_ptr_part0;
+    native_ptr.parts[1] = native_ptr_part1;
+    ret  = wasm_runtime_validate_native_addr(module_inst,
+                                             (void*)(uintptr_t)native_ptr.u64,
+                                             size);
+    if (!ret)
+        wasm_runtime_clear_exception(module_inst);
+    return ret;
+}
+
+static uint64
+wasm_runtime_addr_app_to_native_wrapper(uint32 inst_part0, uint32 inst_part1,
+                                        int32 app_offset)
+{
+    wasm_module_inst_t module_inst =
+        wasm_runtime_get_current_module_inst();
+    union { uint64 u64; uint32 parts[2]; } inst;
+
+    inst.parts[0] = inst_part0;
+    inst.parts[1] = inst_part1;
+
+    if (inst.u64 != (uint64)(uintptr_t)module_inst) {
+        printf("Invalid module instance\n");
+        return 0;
+    }
+    return (uint64)(uintptr_t)
+            wasm_runtime_addr_app_to_native(module_inst, app_offset);
+}
+
+static int32
+wasm_runtime_addr_native_to_app_wrapper(uint32 inst_part0, uint32 inst_part1,
+                                        uint32 native_ptr_part0,
+                                        uint32 native_ptr_part1)
+{
+    wasm_module_inst_t module_inst =
+        wasm_runtime_get_current_module_inst();
+    union { uint64 u64; uint32 parts[2]; } inst;
+    union { uint64 u64; uint32 parts[2]; } native_ptr;
+
+    inst.parts[0] = inst_part0;
+    inst.parts[1] = inst_part1;
+
+     if (inst.u64 != (uint64)(uintptr_t)module_inst) {
+         printf("Invalid module instance\n");
+         return 0;
+     }
+
+    native_ptr.parts[0] = native_ptr_part0;
+    native_ptr.parts[1] = native_ptr_part1;
+    return wasm_runtime_addr_native_to_app(module_inst,
+                                           (void*)(uintptr_t)native_ptr.u64);
+}
 
 static NativeSymbol extended_native_symbol_defs[] = {
 /* TODO: use macro EXPORT_WASM_API() or EXPORT_WASM_API2() to
@@ -38,6 +143,11 @@ static NativeSymbol extended_native_symbol_defs[] = {
         EXPORT_WASM_API(wasm_timer_restart),
         EXPORT_WASM_API(wasm_get_sys_tick_ms),
 #endif
+        EXPORT_WASM_API2(wasm_runtime_get_current_module_inst),
+        EXPORT_WASM_API2(wasm_runtime_validate_app_addr),
+        EXPORT_WASM_API2(wasm_runtime_validate_native_addr),
+        EXPORT_WASM_API2(wasm_runtime_addr_app_to_native),
+        EXPORT_WASM_API2(wasm_runtime_addr_native_to_app),
     };
 
 int get_base_lib_export_apis(NativeSymbol **p_base_lib_apis)

--- a/core/iwasm/products/alios-things/src/main.c
+++ b/core/iwasm/products/alios-things/src/main.c
@@ -29,6 +29,20 @@
 static int app_argc;
 static char **app_argv;
 
+/**
+ * Find the unique main function from a WASM module instance
+ * and execute that function.
+ *
+ * @param module_inst the WASM module instance
+ * @param argc the number of arguments
+ * @param argv the arguments array
+ *
+ * @return true if the main function is called, false otherwise.
+ */
+bool
+wasm_application_execute_main(wasm_module_inst_t module_inst,
+                              int argc, char *argv[]);
+
 static void*
 app_instance_main(wasm_module_inst_t module_inst)
 {

--- a/core/iwasm/products/linux/main.c
+++ b/core/iwasm/products/linux/main.c
@@ -46,6 +46,35 @@ static int print_help()
     return 1;
 }
 
+/**
+ * Find the unique main function from a WASM module instance
+ * and execute that function.
+ *
+ * @param module_inst the WASM module instance
+ * @param argc the number of arguments
+ * @param argv the arguments array
+ *
+ * @return true if the main function is called, false otherwise.
+ */
+bool
+wasm_application_execute_main(wasm_module_inst_t module_inst,
+                              int argc, char *argv[]);
+
+/**
+ * Find the specified function in argv[0] from WASM module of current instance
+ * and execute that function.
+ *
+ * @param module_inst the WASM module instance
+ * @param name the name of the function to execute
+ * @param argc the number of arguments
+ * @param argv the arguments array
+ *
+ * @return true if the specified function is called, false otherwise.
+ */
+bool
+wasm_application_execute_func(wasm_module_inst_t module_inst,
+                              const char *name, int argc, char *argv[]);
+
 static void*
 app_instance_main(wasm_module_inst_t module_inst)
 {

--- a/core/iwasm/products/vxworks/main.c
+++ b/core/iwasm/products/vxworks/main.c
@@ -46,6 +46,35 @@ static int print_help()
     return 1;
 }
 
+/**
+ * Find the unique main function from a WASM module instance
+ * and execute that function.
+ *
+ * @param module_inst the WASM module instance
+ * @param argc the number of arguments
+ * @param argv the arguments array
+ *
+ * @return true if the main function is called, false otherwise.
+ */
+bool
+wasm_application_execute_main(wasm_module_inst_t module_inst,
+                              int argc, char *argv[]);
+
+/**
+ * Find the specified function in argv[0] from WASM module of current instance
+ * and execute that function.
+ *
+ * @param module_inst the WASM module instance
+ * @param name the name of the function to execute
+ * @param argc the number of arguments
+ * @param argv the arguments array
+ *
+ * @return true if the specified function is called, false otherwise.
+ */
+bool
+wasm_application_execute_func(wasm_module_inst_t module_inst,
+                              const char *name, int argc, char *argv[]);
+
 static void*
 app_instance_main(wasm_module_inst_t module_inst)
 {

--- a/core/iwasm/products/zephyr/simple/src/main.c
+++ b/core/iwasm/products/zephyr/simple/src/main.c
@@ -29,6 +29,20 @@
 static int app_argc;
 static char **app_argv;
 
+/**
+ * Find the unique main function from a WASM module instance
+ * and execute that function.
+ *
+ * @param module_inst the WASM module instance
+ * @param argc the number of arguments
+ * @param argv the arguments array
+ *
+ * @return true if the main function is called, false otherwise.
+ */
+bool
+wasm_application_execute_main(wasm_module_inst_t module_inst,
+                              int argc, char *argv[]);
+
 static void*
 app_instance_main(wasm_module_inst_t module_inst)
 {

--- a/core/iwasm/runtime/include/wasm_export.h
+++ b/core/iwasm/runtime/include/wasm_export.h
@@ -152,6 +152,13 @@ wasm_runtime_instantiate(const wasm_module_t module,
 void
 wasm_runtime_deinstantiate(wasm_module_inst_t module_inst);
 
+#if WASM_ENABLE_EXT_MEMORY_SPACE != 0
+bool
+wasm_runtime_set_ext_memory(wasm_module_inst_t module_inst,
+                            uint8_t *ext_mem_data, uint32_t ext_mem_size,
+                            char *error_buf, uint32_t error_buf_size);
+#endif
+
 /**
  * Load WASM module instance from AOT file.
  *
@@ -383,36 +390,6 @@ wasm_runtime_addr_app_to_native(wasm_module_inst_t module_inst,
 int32_t
 wasm_runtime_addr_native_to_app(wasm_module_inst_t module_inst,
                                 void *native_ptr);
-
-/**
- * Find the unique main function from a WASM module instance
- * and execute that function.
- *
- * @param module_inst the WASM module instance
- * @param argc the number of arguments
- * @param argv the arguments array
- *
- * @return true if the main function is called, false otherwise.
- */
-bool
-wasm_application_execute_main(wasm_module_inst_t module_inst,
-                              int argc, char *argv[]);
-
-/**
- * Find the specified function in argv[0] from WASM module of current instance
- * and execute that function.
- *
- * @param module_inst the WASM module instance
- * @param name the name of the function to execute
- * @param argc the number of arguments
- * @param argv the arguments array
- *
- * @return true if the specified function is called, false otherwise.
- */
-bool
-wasm_application_execute_func(wasm_module_inst_t module_inst,
-                              const char *name, int argc, char *argv[]);
-
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/runtime/vmcore-wasm/wasm_runtime.h
+++ b/core/iwasm/runtime/vmcore-wasm/wasm_runtime.h
@@ -148,6 +148,13 @@ typedef struct WASMModuleInstance {
     uint32 temp_ret;
     uint32 llvm_stack;
 
+#if WASM_ENABLE_EXT_MEMORY_SPACE != 0
+    int32 ext_mem_base_offset;
+    uint8 *ext_mem_data;
+    uint8 *ext_mem_data_end;
+    uint32 ext_mem_size;
+#endif
+
     /* Default WASM stack size of threads of this Module instance. */
     uint32 wasm_stack_size;
 

--- a/core/shared-lib/include/config.h
+++ b/core/shared-lib/include/config.h
@@ -115,3 +115,13 @@
 #define APP_THREAD_STACK_SIZE_MAX (256 * 1024)
 #endif
 #endif
+
+/* External memory space provided by user,
+   but not wasm memory space and app heap space */
+#ifndef WASM_ENABLE_EXT_MEMORY_SPACE
+#define WASM_ENABLE_EXT_MEMORY_SPACE 0
+#endif
+
+/* Default base offset of external memory space */
+#define DEFAULT_EXT_MEM_BASE_OFFSET (-2 * BH_GB)
+


### PR DESCRIPTION
Enable setting external memory space for wasm app, the feature is disabled by default;
Remove wasm_application_exectue_* APIs from wasm_export.h which makes confused.