### PR TITLE
Refine binary size and fix several minor issues (#104)

### DIFF
--- a/core/iwasm/lib/native/libc/libc_wrapper.c
+++ b/core/iwasm/lib/native/libc/libc_wrapper.c
@@ -984,23 +984,6 @@ wasm_native_global_lookup(const char *module_name, const char *global_name,
         global_def++;
     }
 
-    /* Lookup non-constant globals which cannot be defined by table */
-    if (!strcmp(module_name, "env")) {
-        if (!strcmp(global_name, "_stdin")) {
-            global->global_data_linked.addr = (uintptr_t)stdin;
-            global->is_addr = true;
-            return true;
-        } else if (!strcmp(global_name, "_stdout")) {
-            global->global_data_linked.addr = (uintptr_t)stdout;
-            global->is_addr = true;
-            return true;
-        } else if (!strcmp(global_name, "_stderr")) {
-            global->global_data_linked.addr = (uintptr_t)stderr;
-            global->is_addr = true;
-            return true;
-        }
-    }
-
     return false;
 }
 

--- a/core/iwasm/products/linux/CMakeLists.txt
+++ b/core/iwasm/products/linux/CMakeLists.txt
@@ -68,6 +68,7 @@ include (../../lib/native/base/wasm_lib_base.cmake)
 include (../../lib/native/libc/wasm_libc.cmake)
 include (${SHARED_LIB_DIR}/platform/${PLATFORM}/shared_platform.cmake)
 include (${SHARED_LIB_DIR}/mem-alloc/mem_alloc.cmake)
+include (${SHARED_LIB_DIR}/utils/shared_utils.cmake)
 
 add_library (vmlib
              ${WASM_PLATFORM_LIB_SOURCE}
@@ -76,7 +77,8 @@ add_library (vmlib
              ${WASM_LIB_BASE_DIR}/base_lib_export.c
              ${WASM_LIBC_SOURCE}
              ${PLATFORM_SHARED_SOURCE}
-             ${MEM_ALLOC_SHARED_SOURCE})
+             ${MEM_ALLOC_SHARED_SOURCE}
+             ${UTILS_SHARED_SOURCE})
 
 add_executable (iwasm main.c ext_lib_export.c)
 
@@ -91,7 +93,8 @@ add_library (libiwasm SHARED
              ${WASM_LIB_BASE_DIR}/base_lib_export.c
              ${WASM_LIBC_SOURCE}
              ${PLATFORM_SHARED_SOURCE}
-             ${MEM_ALLOC_SHARED_SOURCE})
+             ${MEM_ALLOC_SHARED_SOURCE}
+             ${UTILS_SHARED_SOURCE})
 
 install (TARGETS libiwasm DESTINATION lib)
 

--- a/core/iwasm/runtime/include/bh_memory.h
+++ b/core/iwasm/runtime/include/bh_memory.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _BH_MEMORY_H
+#define _BH_MEMORY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BH_KB (1024)
+#define BH_MB ((BH_KB)*1024)
+#define BH_GB ((BH_MB)*1024)
+
+/**
+ * Initialize memory allocator with a pool, the bh_malloc/bh_free function
+ * will malloc/free memory from the pool
+ *
+ * @param mem the pool buffer
+ * @param bytes the size bytes of the buffer
+ *
+ * @return 0 if success, -1 otherwise
+ */
+int bh_memory_init_with_pool(void *mem, unsigned int bytes);
+
+/**
+ * Initialize memory allocator with memory allocator, the bh_malloc/bh_free
+ * function will malloc/free memory with the allocator passed
+ *
+ * @param malloc_func the malloc function
+ * @param free_func the free function
+ *
+ * @return 0 if success, -1 otherwise
+ */
+int bh_memory_init_with_allocator(void *malloc_func, void *free_func);
+
+/**
+ * Destroy memory
+ */
+void bh_memory_destroy();
+
+/**
+ * Get the pool size of memory, if memory is initialized with allocator,
+ * return 1GB by default.
+ */
+int bh_memory_pool_size();
+
+#if BEIHAI_ENABLE_MEMORY_PROFILING == 0
+
+/**
+ * This function allocates a memory chunk from system
+ *
+ * @param size bytes need allocate
+ *
+ * @return the pointer to memory allocated
+ */
+void* bh_malloc(unsigned int size);
+
+/**
+ * This function frees memory chunk
+ *
+ * @param ptr the pointer to memory need free
+ */
+void bh_free(void *ptr);
+
+#else
+
+void* bh_malloc_profile(const char *file, int line, const char *func, unsigned int size);
+void bh_free_profile(const char *file, int line, const char *func, void *ptr);
+
+#define bh_malloc(size) bh_malloc_profile(__FILE__, __LINE__, __func__, size)
+#define bh_free(ptr) bh_free_profile(__FILE__, __LINE__, __func__, ptr)
+
+/**
+ * Print current memory profiling data
+ *
+ * @param file file name of the caller
+ * @param line line of the file of the caller
+ * @param func function name of the caller
+ */
+void memory_profile_print(const char *file, int line, const char *func, int alloc);
+
+/**
+ * Summarize memory usage and print it out
+ * Can use awk to analyze the output like below:
+ * awk -F: '{print $2,$4,$6,$8,$9}' OFS="\t" ./out.txt | sort -n -r -k 1
+ */
+void memory_usage_summarize();
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* #ifndef _BH_MEMORY_H */
+

--- a/core/iwasm/runtime/vmcore-wasm/wasm_application.c
+++ b/core/iwasm/runtime/vmcore-wasm/wasm_application.c
@@ -293,10 +293,15 @@ wasm_application_execute_func(WASMModuleInstance *module_inst,
             break;
         case VALUE_TYPE_I64:
         {
+            char buf[16];
             union { uint64 val; uint32 parts[2]; } u;
             u.parts[0] = argv1[0];
             u.parts[1] = argv1[1];
-            wasm_printf("0x%llx:i64", u.val);
+            if (sizeof(long) == 4)
+                snprintf(buf, sizeof(buf), "%s", "0x%llx:i64");
+            else
+                snprintf(buf, sizeof(buf), "%s", "0x%lx:i64");
+            wasm_printf(buf, u.val);
             break;
         }
         case VALUE_TYPE_F32:

--- a/core/iwasm/runtime/vmcore-wasm/wasm_runtime.c
+++ b/core/iwasm/runtime/vmcore-wasm/wasm_runtime.c
@@ -947,18 +947,11 @@ wasm_runtime_instantiate(WASMModule *module,
     wasm_runtime_set_tlr(&module_inst->main_tlr);
     module_inst->main_tlr.handle = ws_self_thread();
 
-    /* Execute __post_instantiate function */
-    if (!execute_post_inst_function(module_inst)) {
-        const char *exception = wasm_runtime_get_exception(module_inst);
-        wasm_printf("%s\n", exception);
-        wasm_runtime_deinstantiate(module_inst);
-        return NULL;
-    }
-
-    /* Execute start function */
-    if (!execute_start_function(module_inst)) {
-        const char *exception = wasm_runtime_get_exception(module_inst);
-        wasm_printf("%s\n", exception);
+    /* Execute __post_instantiate and start function */
+    if (!execute_post_inst_function(module_inst)
+        || !execute_start_function(module_inst)) {
+        set_error_buf(error_buf, error_buf_size,
+                      module_inst->cur_exception);
         wasm_runtime_deinstantiate(module_inst);
         return NULL;
     }


### PR DESCRIPTION
* Implement memory profiler, optimize memory usage, modify code indent

* Implement memory.grow and limit heap space base offset to 1G; modify iwasm build type to Release and 64 bit by default

* Add a new extension library: connection

* Fix bug of reading magic number and version in big endian platform

* Re-org platform APIs: move most platform APIs from iwasm to shared-lib

* Enhance wasm loader to fix some security issues

* Fix issue about illegal load of EXC_RETURN into PC on stm32 board

* Updates that let a restricted version of the interpreter run in SGX

* Enable native/app address validation and conversion for wasm app

* Remove wasm_application_exectue_* APIs from wasm_export.h which makes confused

* Refine binary size and fix several minor issues

Optimize interpreter LOAD/STORE opcodes to decrease the binary size
Fix issues when using iwasm library: _bh_log undefined, bh_memory.h not found
Remove unused _stdin/_stdout/_stderr global variables resolve in libc wrapper
Add macros of global heap size, stack size, heap size for Zephyr main.c
Clear compile warning of wasm_application.c