### PR TITLE
Refine wgl lib and refine wasm function index check (#122)

### DIFF
--- a/core/iwasm/lib/native/extension/gui/wgl_btn_wrapper.c
+++ b/core/iwasm/lib/native/extension/gui/wgl_btn_wrapper.c
@@ -51,7 +51,8 @@ wasm_btn_native_call(wasm_module_inst_t module_inst,
 {
     uint32 size = sizeof(btn_native_func_defs) / sizeof(WGLNativeFuncDef);
 
-    wgl_native_func_call(btn_native_func_defs,
+    wgl_native_func_call(module_inst,
+                         btn_native_func_defs,
                          size,
                          func_id,
                          argv_offset,

--- a/core/iwasm/lib/native/extension/gui/wgl_cb_wrapper.c
+++ b/core/iwasm/lib/native/extension/gui/wgl_cb_wrapper.c
@@ -23,12 +23,14 @@
 /* -------------------------------------------------------------------------
  * Label widget native function wrappers
  * -------------------------------------------------------------------------*/
-static int32 _cb_create(lv_obj_t *par, lv_obj_t *copy)
+static int32
+_cb_create(lv_obj_t *par, lv_obj_t *copy)
 {
     return wgl_native_wigdet_create(WIDGET_TYPE_CB, par, copy);
 }
 
-static int32 _cb_get_text_length(lv_obj_t *cb)
+static int32
+_cb_get_text_length(lv_obj_t *cb)
 {
     const char *text = lv_cb_get_text(cb);
 
@@ -38,9 +40,9 @@ static int32 _cb_get_text_length(lv_obj_t *cb)
     return strlen(text);
 }
 
-static int32 _cb_get_text(lv_obj_t *cb, char *buffer, int buffer_len)
+static char *
+_cb_get_text(lv_obj_t *cb, char *buffer, int buffer_len)
 {
-    wasm_module_inst_t module_inst = get_module_inst();
     const char *text = lv_cb_get_text(cb);
 
     if (text == NULL)
@@ -49,7 +51,7 @@ static int32 _cb_get_text(lv_obj_t *cb, char *buffer, int buffer_len)
     strncpy(buffer, text, buffer_len - 1);
     buffer[buffer_len - 1] = '\0';
 
-    return addr_native_to_app(buffer);
+    return buffer;
 }
 
 static WGLNativeFuncDef cb_native_func_defs[] = {
@@ -57,7 +59,7 @@ static WGLNativeFuncDef cb_native_func_defs[] = {
         { CB_FUNC_ID_SET_TEXT, lv_cb_set_text, NO_RET, 2, {0, -1}, {1, -1} },
         { CB_FUNC_ID_SET_STATIC_TEXT, lv_cb_set_static_text, NO_RET, 2, {0, -1}, {1, -1} },
         { CB_FUNC_ID_GET_TEXT_LENGTH, _cb_get_text_length, HAS_RET, 1, {0, -1}, {-1} },
-        { CB_FUNC_ID_GET_TEXT, _cb_get_text, HAS_RET, 3, {0, -1}, {1, -1} },
+        { CB_FUNC_ID_GET_TEXT, _cb_get_text, RET_PTR, 3, {0, -1}, {1, -1} },
 };
 
 /*************** Native Interface to Wasm App ***********/
@@ -67,7 +69,8 @@ wasm_cb_native_call(wasm_module_inst_t module_inst,
 {
     uint32 size = sizeof(cb_native_func_defs) / sizeof(WGLNativeFuncDef);
 
-    wgl_native_func_call(cb_native_func_defs,
+    wgl_native_func_call(module_inst,
+                         cb_native_func_defs,
                          size,
                          func_id,
                          argv_offset,

--- a/core/iwasm/lib/native/extension/gui/wgl_label_wrapper.c
+++ b/core/iwasm/lib/native/extension/gui/wgl_label_wrapper.c
@@ -23,12 +23,14 @@
 /* -------------------------------------------------------------------------
  * Label widget native function wrappers
  * -------------------------------------------------------------------------*/
-static int32 _label_create(lv_obj_t *par, lv_obj_t *copy)
+static int32
+_label_create(lv_obj_t *par, lv_obj_t *copy)
 {
     return wgl_native_wigdet_create(WIDGET_TYPE_LABEL, par, copy);
 }
 
-static int32 _label_get_text_length(lv_obj_t *label)
+static int32
+_label_get_text_length(lv_obj_t *label)
 {
     char *text = lv_label_get_text(label);
 
@@ -38,9 +40,9 @@ static int32 _label_get_text_length(lv_obj_t *label)
     return strlen(text);
 }
 
-static int32 _label_get_text(lv_obj_t *label, char *buffer, int buffer_len)
+static char *
+_label_get_text(lv_obj_t *label, char *buffer, int buffer_len)
 {
-    wasm_module_inst_t module_inst = get_module_inst();
     char *text = lv_label_get_text(label);
 
     if (text == NULL)
@@ -49,14 +51,14 @@ static int32 _label_get_text(lv_obj_t *label, char *buffer, int buffer_len)
     strncpy(buffer, text, buffer_len - 1);
     buffer[buffer_len - 1] = '\0';
 
-    return addr_native_to_app(buffer);
+    return buffer;
 }
 
 static WGLNativeFuncDef label_native_func_defs[] = {
         { LABEL_FUNC_ID_CREATE, _label_create, HAS_RET, 2, {0 | NULL_OK, 1 | NULL_OK, -1}, {-1} },
         { LABEL_FUNC_ID_SET_TEXT, lv_label_set_text, NO_RET, 2, {0, -1}, {1, -1} },
         { LABEL_FUNC_ID_GET_TEXT_LENGTH, _label_get_text_length, HAS_RET, 1, {0, -1}, {-1} },
-        { LABEL_FUNC_ID_GET_TEXT, _label_get_text, HAS_RET, 3, {0, -1}, {1, -1} },
+        { LABEL_FUNC_ID_GET_TEXT, _label_get_text, RET_PTR, 3, {0, -1}, {1, -1} },
 };
 
 /*************** Native Interface to Wasm App ***********/
@@ -66,7 +68,8 @@ wasm_label_native_call(wasm_module_inst_t module_inst,
 {
     uint32 size = sizeof(label_native_func_defs) / sizeof(WGLNativeFuncDef);
 
-    wgl_native_func_call(label_native_func_defs,
+    wgl_native_func_call(module_inst,
+                         label_native_func_defs,
                          size,
                          func_id,
                          argv_offset,

--- a/core/iwasm/lib/native/extension/gui/wgl_list_wrapper.c
+++ b/core/iwasm/lib/native/extension/gui/wgl_list_wrapper.c
@@ -57,7 +57,8 @@ wasm_list_native_call(wasm_module_inst_t module_inst,
 {
     uint32 size = sizeof(list_native_func_defs) / sizeof(WGLNativeFuncDef);
 
-    wgl_native_func_call(list_native_func_defs,
+    wgl_native_func_call(module_inst,
+                         list_native_func_defs,
                          size,
                          func_id,
                          argv_offset,

--- a/core/iwasm/lib/native/extension/gui/wgl_native_utils.h
+++ b/core/iwasm/lib/native/extension/gui/wgl_native_utils.h
@@ -17,8 +17,12 @@ extern "C" {
 #define NULL_OK  0x80
 
 enum {
+    /* The function has a normal return value (not a pointer) */
     HAS_RET,
-    NO_RET
+    /* The function doesn't have return value */
+    NO_RET,
+    /* The function's return value is a native address pointer */
+    RET_PTR
 };
 
 enum {
@@ -61,14 +65,12 @@ uint32 wgl_native_wigdet_create(int8 widget_type,
                                 lv_obj_t *par,
                                 lv_obj_t *copy);
 
-void wgl_native_func_call(WGLNativeFuncDef *funcs,
+void wgl_native_func_call(wasm_module_inst_t module_inst,
+                          WGLNativeFuncDef *funcs,
                           uint32 size,
                           int32 func_id,
                           uint32 argv_offset,
                           uint32 argc);
-
-wasm_module_inst_t wasm_runtime_get_current_module_inst();
-#define get_module_inst() wasm_runtime_get_current_module_inst()
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/lib/native/extension/gui/wgl_obj_wrapper.c
+++ b/core/iwasm/lib/native/extension/gui/wgl_obj_wrapper.c
@@ -347,7 +347,8 @@ wasm_obj_native_call(wasm_module_inst_t module_inst,
 {
     uint32 size = sizeof(obj_native_func_defs) / sizeof(WGLNativeFuncDef);
 
-    wgl_native_func_call(obj_native_func_defs,
+    wgl_native_func_call(module_inst,
+                         obj_native_func_defs,
                          size,
                          func_id,
                          argv_offset,

--- a/core/iwasm/runtime/vmcore-wasm/wasm_interp.c
+++ b/core/iwasm/runtime/vmcore-wasm/wasm_interp.c
@@ -880,11 +880,8 @@ wasm_interp_call_func_bytecode(WASMThread *self,
           }
 
           fidx = ((uint32*)table->base_addr)[val];
-          if (fidx >= module->function_count) {
-            wasm_runtime_set_exception(module, "function index is overflow");
-            goto got_exception;
-          }
-
+          /* Skip function index check, it has been checked
+             in wasm module instantiate */
           cur_func = module->functions + fidx;
 
           if (cur_func->is_import_func)


### PR DESCRIPTION
Refine wgl lib: remove module_inst parameter from widget functions
Refine wasm function check: move function index check from interpreter call_indirect to runtime instantiate