### PR TITLE
Add a switch to build simple sample without gui support (#126)

### DIFF
--- a/core/iwasm/lib/app-libs/base/wasm_app.h
+++ b/core/iwasm/lib/app-libs/base/wasm_app.h
@@ -38,7 +38,10 @@
 #include "sensor.h"
 #include "connection.h"
 #include "timer_wasm_app.h"
+
+#if ENABLE_WGL != 0
 #include "wgl.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/core/iwasm/lib/native-interface/shared_utils.h
+++ b/core/iwasm/lib/native-interface/shared_utils.h
@@ -156,7 +156,9 @@ unpack_response(char * packet, int size, response_t * response);
 void
 free_req_resp_packet(char * packet);
 
+#if WASM_ENABLE_GUI != 0
 #include "wgl_shared_utils.h"
+#endif
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/runtime/vmcore-wasm/wasm_interp.c
+++ b/core/iwasm/runtime/vmcore-wasm/wasm_interp.c
@@ -1795,7 +1795,13 @@ wasm_interp_call_func_bytecode(WASMThread *self,
 
         b = POP_F32();
         a = POP_F32();
-        PUSH_F32(wa_fmin(a, b));
+
+        if (isnan(a))
+            PUSH_F32(a);
+        else if (isnan(b))
+            PUSH_F32(b);
+        else
+            PUSH_F32(wa_fmin(a, b));
         HANDLE_OP_END ();
       }
 
@@ -1805,7 +1811,13 @@ wasm_interp_call_func_bytecode(WASMThread *self,
 
         b = POP_F32();
         a = POP_F32();
-        PUSH_F32(wa_fmax(a, b));
+
+        if (isnan(a))
+            PUSH_F32(a);
+        else if (isnan(b))
+            PUSH_F32(b);
+        else
+            PUSH_F32(wa_fmax(a, b));
         HANDLE_OP_END ();
       }
 
@@ -1870,7 +1882,13 @@ wasm_interp_call_func_bytecode(WASMThread *self,
 
         b = POP_F64();
         a = POP_F64();
-        PUSH_F64(wa_fmin(a, b));
+
+        if (isnan(a))
+            PUSH_F64(a);
+        else if (isnan(b))
+            PUSH_F64(b);
+        else
+            PUSH_F64(wa_fmin(a, b));
         HANDLE_OP_END ();
       }
 
@@ -1880,7 +1898,13 @@ wasm_interp_call_func_bytecode(WASMThread *self,
 
         b = POP_F64();
         a = POP_F64();
-        PUSH_F64(wa_fmax(a, b));
+
+        if (isnan(a))
+            PUSH_F64(a);
+        else if (isnan(b))
+            PUSH_F64(b);
+        else
+            PUSH_F64(wa_fmax(a, b));
         HANDLE_OP_END ();
       }
 

--- a/core/shared-lib/include/config.h
+++ b/core/shared-lib/include/config.h
@@ -131,3 +131,6 @@
 #define bh_printf printf
 #endif
 
+#ifndef WASM_ENABLE_GUI
+#define WASM_ENABLE_GUI 0
+#endif

--- a/samples/gui/wasm-apps/lvgl-compatible/Makefile
+++ b/samples/gui/wasm-apps/lvgl-compatible/Makefile
@@ -18,6 +18,7 @@ IWASM_DIR=../../../../core/iwasm
 CFLAGS += -O3 \
 	  -Wno-int-conversion \
 	  -DLV_CONF_INCLUDE_SIMPLE \
+	  -DENABLE_WGL=1 \
 	  -I$(APP_DIR)/src/ \
 	  -I$(IWASM_DIR)/lib/app-libs/base/ \
 	  -I$(IWASM_DIR)/lib/native-interface/ \

--- a/samples/gui/wasm-apps/wgl/Makefile
+++ b/samples/gui/wasm-apps/wgl/Makefile
@@ -18,6 +18,7 @@ IWASM_DIR=../../../../core/iwasm
 CFLAGS += -O3 \
 	  -Wno-int-conversion \
 	  -DLV_CONF_INCLUDE_SIMPLE \
+	  -DENABLE_WGL=1 \
 	  -I$(APP_DIR)/src/ \
 	  -I$(IWASM_DIR)/lib/app-libs/base/ \
 	  -I$(IWASM_DIR)/lib/native-interface/ \

--- a/samples/gui/wasm-runtime-wgl/linux-build/CMakeLists.txt
+++ b/samples/gui/wasm-runtime-wgl/linux-build/CMakeLists.txt
@@ -82,6 +82,7 @@ add_definitions (-DWASM_ENABLE_BASE_LIB)
 add_definitions (-Dattr_container_malloc=bh_malloc)
 add_definitions (-Dattr_container_free=bh_free)
 add_definitions (-DLV_CONF_INCLUDE_SIMPLE)
+add_definitions (-DWASM_ENABLE_GUI=1)
 
 add_library (vmlib
              ${WASM_PLATFORM_LIB_SOURCE}

--- a/samples/gui/wasm-runtime-wgl/zephyr-build/CMakeLists.txt
+++ b/samples/gui/wasm-runtime-wgl/zephyr-build/CMakeLists.txt
@@ -24,7 +24,8 @@ zephyr_compile_definitions (-DNVALGRIND
     -D__ZEPHYR__
     -DWASM_ENABLE_BASE_LIB
     -Dattr_container_malloc=bh_malloc
-    -Dattr_container_free=bh_free)
+    -Dattr_container_free=bh_free
+    -DWASM_ENABLE_GUI=1)
 
 set (IWASM_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/core/iwasm)
 set (APP_MGR_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/core/app-mgr)

--- a/samples/simple/CMakeLists.txt
+++ b/samples/simple/CMakeLists.txt
@@ -48,10 +48,11 @@ set(WASM_DIR  ${WAMR_ROOT_DIR}/core/iwasm)
 set(APP_MGR_DIR ${WAMR_ROOT_DIR}/core/app-mgr)
 set(SHARED_DIR ${WAMR_ROOT_DIR}/core/shared-lib)
 
-set (LV_DRIVERS_DIR ${WASM_DIR}/lib/3rdparty/lv_drivers)
-set (LVGL_DIR ${WASM_DIR}/lib/3rdparty/lvgl)
-
-file(GLOB_RECURSE LV_DRIVERS_SOURCES "${LV_DRIVERS_DIR}/*.c" )
+if ("${ENABLE_GUI}" STREQUAL "YES")
+    set (LV_DRIVERS_DIR ${WASM_DIR}/lib/3rdparty/lv_drivers)
+    set (LVGL_DIR ${WASM_DIR}/lib/3rdparty/lvgl)
+    file(GLOB_RECURSE LV_DRIVERS_SOURCES "${LV_DRIVERS_DIR}/*.c" )
+endif()
 
 enable_language (ASM)
 
@@ -61,7 +62,9 @@ include (${WASM_DIR}/runtime/vmcore-wasm/vmcore.cmake)
 include (${WASM_DIR}/lib/native/base/wasm_lib_base.cmake)
 include (${WASM_DIR}/lib/native/libc/wasm_libc.cmake)
 include (${WASM_DIR}/lib/native/extension/sensor/wasm_lib_sensor.cmake)
-include (${WASM_DIR}/lib/native/extension/gui/wasm_lib_gui.cmake)
+if ("${ENABLE_GUI}" STREQUAL "YES")
+    include (${WASM_DIR}/lib/native/extension/gui/wasm_lib_gui.cmake)
+endif()
 include (${WASM_DIR}/lib/native/extension/connection/wasm_lib_conn.cmake)
 include (${WASM_DIR}/lib/native/extension/connection/${TARGET_PLATFORM}/connection_mgr.cmake)
 include (${WASM_DIR}/lib/native-interface/native_interface.cmake)
@@ -83,6 +86,10 @@ add_definitions (-Dattr_container_malloc=bh_malloc)
 add_definitions (-Dattr_container_free=bh_free)
 add_definitions (-DLV_CONF_INCLUDE_SIMPLE)
 
+if ("${ENABLE_GUI}" STREQUAL "YES")
+    add_definitions (-DWASM_ENABLE_GUI=1)
+endif()
+
 add_library (vmlib
              ${WASM_PLATFORM_LIB_SOURCE}
              ${WASM_UTILS_LIB_SOURCE}
@@ -101,7 +108,12 @@ add_library (vmlib
              ${NATIVE_INTERFACE_SOURCE}
             )
 
+if ("${ENABLE_GUI}" STREQUAL "YES")
     add_executable (simple src/main.c src/iwasm_main.c src/ext_lib_export.c ${LV_DRIVERS_SOURCES})
+    target_link_libraries (simple vmlib -lm -ldl -lpthread -lSDL2)
+else ()
+    add_executable (simple src/main.c src/iwasm_main.c src/ext_lib_export.c)
+    target_link_libraries (simple vmlib -lm -ldl -lpthread)
+endif ()
 
-target_link_libraries (simple vmlib -lm -ldl -lpthread -lSDL2)
 

--- a/samples/simple/README.md
+++ b/samples/simple/README.md
@@ -28,6 +28,8 @@ simple/
 
 - build.sh<br/>
   The script to build all binaries.
+- build_no_gui.sh<br/>
+  The script to build all binaries without gui library support.
 - CMakeLists.txt<br/>
   CMake file used to build the simple application.
 - README.md<br/>
@@ -100,6 +102,9 @@ Build all binaries
 ==============
 Execute the build.sh script then all binaries including wasm application files would be generated in 'out' directory.
 `./build.sh`
+
+Or execute the build_no_gui.sh script to build all binaries without gui library support.
+`./build_no_gui.sh`
 
 Out directory structure
 ------------------------------

--- a/samples/simple/build_no_gui.sh
+++ b/samples/simple/build_no_gui.sh
@@ -8,7 +8,7 @@ BUILD_DIR=${PWD}/build
 IWASM_ROOT=${PWD}/../../core/iwasm
 APP_LIBS=${IWASM_ROOT}/lib/app-libs
 NATIVE_LIBS=${IWASM_ROOT}/lib/native-interface
-APP_LIB_SRC="${APP_LIBS}/base/*.c ${APP_LIBS}/extension/sensor/*.c ${APP_LIBS}/extension/connection/*.c ${APP_LIBS}/extension/gui/src/*.c ${NATIVE_LIBS}/*.c"
+APP_LIB_SRC="${APP_LIBS}/base/*.c ${APP_LIBS}/extension/sensor/*.c ${APP_LIBS}/extension/connection/*.c ${NATIVE_LIBS}/*.c"
 WASM_APPS=${PWD}/wasm-apps
 
 rm -rf ${OUT_DIR}
@@ -20,19 +20,11 @@ if [ ! -d "tlsf" ]; then
     git clone https://github.com/mattconte/tlsf
 fi
 
-cd ${WAMR_DIR}/core/iwasm/lib/3rdparty
-if [ ! -d "lvgl" ]; then
-    git clone https://github.com/littlevgl/lvgl.git --branch v6.0.1
-fi
-if [ ! -d "lv_drivers" ]; then
-        git clone https://github.com/littlevgl/lv_drivers.git
-fi
-
 echo "#####################build simple project"
 cd ${CURR_DIR}
 mkdir -p cmake_build
 cd cmake_build
-cmake -DENABLE_GUI=YES ..
+cmake -DENABLE_GUI=NO ..
 make
 if [ $? != 0 ];then
     echo "BUILD_FAIL simple exit as $?\n"
@@ -59,18 +51,16 @@ echo "#####################build wasm apps"
 
 cd ${WASM_APPS}
 
-for i in `ls *.c`
+for i in `ls *.c | grep -v gui`
 do
 APP_SRC="$i ${APP_LIB_SRC}"
 OUT_FILE=${i%.*}.wasm
 emcc -O3 -I${APP_LIBS}/base -I${APP_LIBS}/extension/sensor -I${NATIVE_LIBS} \
      -I${APP_LIBS}/extension/connection \
-     -I${APP_LIBS}/extension/gui \
-     -DENABLE_WGL=1 \
      -s WASM=1 -s SIDE_MODULE=1 -s ASSERTIONS=1 -s STACK_OVERFLOW_CHECK=2 \
      -s TOTAL_MEMORY=65536 -s TOTAL_STACK=4096 \
      -s "EXPORTED_FUNCTIONS=['_on_init', '_on_destroy', '_on_request', '_on_response', \
-                             '_on_sensor_event', '_on_timer_callback', '_on_connection_data', '_on_widget_event']" \
+                             '_on_sensor_event', '_on_timer_callback', '_on_connection_data']" \
      -o ${OUT_DIR}/wasm-apps/${OUT_FILE} ${APP_SRC}
 if [ -f ${OUT_DIR}/wasm-apps/${OUT_FILE} ]; then
         echo "build ${OUT_FILE} success"

--- a/samples/simple/src/ext_lib_export.c
+++ b/samples/simple/src/ext_lib_export.c
@@ -1,12 +1,17 @@
 #include "lib_export.h"
 #include "sensor_api.h"
 #include "connection_api.h"
+
+#if WASM_ENABLE_GUI != 0
 #include "gui_api.h"
+#endif
 
 static NativeSymbol extended_native_symbol_defs[] = {
 #include "runtime_sensor.inl"
 #include "connection.inl"
+#if WASM_ENABLE_GUI != 0
 #include "wamr_gui.inl"
+#endif
         };
 
 #include "ext_lib_export.h"

--- a/samples/simple/src/iwasm_main.c
+++ b/samples/simple/src/iwasm_main.c
@@ -33,8 +33,10 @@
 #include "module_wasm_app.h"
 #include "wasm_export.h"
 
+#if WASM_ENABLE_GUI != 0
 #include "lv_drivers/display/monitor.h"
 #include "lv_drivers/indev/mouse.h"
+#endif
 
 #define MAX 2048
 
@@ -430,6 +432,7 @@ static bool parse_args(int argc, char *argv[])
     return true;
 }
 
+#if WASM_ENABLE_GUI != 0
 /**
  * Initialize the Hardware Abstraction Layer (HAL) for the Littlev graphics library
  */
@@ -461,6 +464,8 @@ static void hal_init(void)
     indev_drv.read_cb = mouse_read;         /*This function will be called periodically (by the library) to get the mouse position and state*/
     lv_indev_drv_register(&indev_drv);
 }
+#endif
+
 // Driver function
 int iwasm_main(int argc, char *argv[])
 {
@@ -484,8 +489,11 @@ int iwasm_main(int argc, char *argv[])
         goto fail1;
     }
 
+#if WASM_ENABLE_GUI != 0
     wgl_init();
     hal_init();
+#endif
+
     init_sensor_framework();
 
     // timer manager


### PR DESCRIPTION
* Implement memory profiler, optimize memory usage, modify code indent

* Implement memory.grow and limit heap space base offset to 1G; modify iwasm build type to Release and 64 bit by default

* Add a new extension library: connection

* Fix bug of reading magic number and version in big endian platform

* Re-org platform APIs: move most platform APIs from iwasm to shared-lib

* Enhance wasm loader to fix some security issues

* Fix issue about illegal load of EXC_RETURN into PC on stm32 board

* Updates that let a restricted version of the interpreter run in SGX

* Enable native/app address validation and conversion for wasm app

* Remove wasm_application_exectue_* APIs from wasm_export.h which makes confused

* Refine binary size and fix several minor issues

Optimize interpreter LOAD/STORE opcodes to decrease the binary size
Fix issues when using iwasm library: _bh_log undefined, bh_memory.h not found
Remove unused _stdin/_stdout/_stderr global variables resolve in libc wrapper
Add macros of global heap size, stack size, heap size for Zephyr main.c
Clear compile warning of wasm_application.c

* Add more strict security checks for libc wrapper API's

* Use one libc wrapper copy for sgx and other platforms; remove bh_printf macro for other platform header files

* Enhance security of libc strcpy/sprintf wrapper function

* Fix issue of call native for x86_64/arm/mips, add module inst parameter for native wrapper functions

* Remove get_module_inst() and fix issue of call native

* Refine wgl lib: remove module_inst parameter from widget functions; move function index check to runtime instantiate

* Refine interpreter call native process, refine memory boudary check

* Fix issues of invokeNative function of arm/mips/general version

* Add a switch to build simple sample without gui support