### PR TITLE
MacOs: fix wamrc Error invaid llvm binary bin_type (#269)

### DIFF
--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -1394,7 +1394,11 @@ aot_resolve_target_info(AOTCompContext *comp_ctx, AOTObjectData *obj_data)
     if (bin_type != LLVMBinaryTypeELF32L
         && bin_type != LLVMBinaryTypeELF32B
         && bin_type != LLVMBinaryTypeELF64L
-        && bin_type != LLVMBinaryTypeELF64B) {
+        && bin_type != LLVMBinaryTypeELF64B
+        && bin_type != LLVMBinaryTypeMachO32L
+        && bin_type != LLVMBinaryTypeMachO32B
+        && bin_type != LLVMBinaryTypeMachO64L
+        && bin_type != LLVMBinaryTypeMachO64B) {
         aot_set_last_error("invaid llvm binary bin_type.");
         return false;
     }


### PR DESCRIPTION
* add darwin support for wamr-compiler compiling

* add darwin support for wamr-compiler

* Update CMakeLists.txt

* MacOs: fix wamrc Error invaid llvm binary bin_type

Co-authored-by: wenyongh <wenyong.huang@intel.com>