### PR TITLE
Implement memory access bound check with hardware trap for 64-bit platforms (#293)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ Following platforms are supported. Refer to [WAMR porting guide](./doc/port_wamr
 
 - [Linux](./doc/build_wamr.md#linux), [Zephyr](./doc/build_wamr.md#zephyr), [MacOS](./doc/build_wamr.md#macos), [VxWorks](./doc/build_wamr.md#vxworks), [AliOS-Things](./doc/build_wamr.md#alios-things), [Intel Software Guard Extention (Linux)](./doc/build_wamr.md#linux-sgx-intel-software-guard-extention), [Android](./doc/build_wamr.md#android)
 
+### Build iwasm VM core (mini product)
 
+WAMR supports building the iwasm VM core only (no app framework) to the mini product. The WAMR mini product takes the WASM application file name or AoT file name as input and then executes it. For the detailed procedure, please see **[build WAMR VM core](./doc/build_wamr.md)** and **[build and run WASM application](./doc/build_wasm_app.md)**. Also we can click the link of each platform above to see how to build iwasm on it.
 
 ### Build wamrc AoT compiler
 
-Execute following commands to build **wamrc** compiler:
+Both wasm binary file and AoT file are supported by iwasm. The wamrc AoT compiler is to compile wasm binary file to AoT file which can also be run by iwasm. Execute following commands to build **wamrc** compiler:
 
 ```shell
 cd wamr-compiler
@@ -68,12 +70,6 @@ make
 ln -s {current path}/wamrc /usr/bin/wamrc
 ```
 For MacOS, you should replace `cmake ..` with `cmake -DWAMR_BUILD_PLATFORM=darwin ..`.
-
-### Build the mini product
-
-WAMR supports building the iwasm VM core only (no app framework) to the mini product.  The WAMR mini product takes the WASM application file name as input and then executes it. For the detailed procedure, see **[build WAMR VM core](./doc/build_wamr.md)** and **[build and run WASM application](./doc/build_wasm_app.md)**.
-
-
 
 Application framework
 ===================================

--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -158,3 +158,8 @@ if (WAMR_BUILD_MINI_LOADER EQUAL 1)
 else ()
   add_definitions (-DWASM_ENABLE_MINI_LOADER=0)
 endif ()
+if (WAMR_DISABLE_HW_BOUND_CHECK EQUAL 1)
+  add_definitions (-DWASM_DISABLE_HW_BOUND_CHECK=1)
+  message ("     Hardware boundary check disabled")
+endif ()
+

--- a/core/config.h
+++ b/core/config.h
@@ -149,6 +149,12 @@ enum {
 #define WASM_ENABLE_MINI_LOADER 0
 #endif
 
+/* Disable boundary check with hardware trap or not,
+ * enable it by default if it is supported */
+#ifndef WASM_DISABLE_HW_BOUND_CHECK
+#define WASM_DISABLE_HW_BOUND_CHECK 0
+#endif
+
 /* Heap and stack profiling */
 #define BH_ENABLE_MEMORY_PROFILING 0
 
@@ -199,8 +205,8 @@ enum {
 
 /* Default/min/max stack size of each app thread */
 #if !defined(BH_PLATFORM_ZEPHYR) && !defined(BH_PLATFORM_ALIOS_THINGS)
-#define APP_THREAD_STACK_SIZE_DEFAULT (20 * 1024)
-#define APP_THREAD_STACK_SIZE_MIN (16 * 1024)
+#define APP_THREAD_STACK_SIZE_DEFAULT (32 * 1024)
+#define APP_THREAD_STACK_SIZE_MIN (24 * 1024)
 #define APP_THREAD_STACK_SIZE_MAX (256 * 1024)
 #else
 #define APP_THREAD_STACK_SIZE_DEFAULT (6 * 1024)

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -198,14 +198,12 @@ typedef struct AOTModuleInstance {
     /* WASI context */
     AOTPointer wasi_ctx;
 
-    /* total memory size: heap and linear memory */
-    uint32 total_mem_size;
-
     /* boundary check constants for aot code */
-    uint32 mem_bound_check_1byte;
-    uint32 mem_bound_check_2bytes;
-    uint32 mem_bound_check_4bytes;
-    uint32 mem_bound_check_8bytes;
+    int64 mem_bound_check_heap_base;
+    int64 mem_bound_check_1byte;
+    int64 mem_bound_check_2bytes;
+    int64 mem_bound_check_4bytes;
+    int64 mem_bound_check_8bytes;
 
     /* others */
     int32 temp_ret;
@@ -467,6 +465,14 @@ aot_memory_init(AOTModuleInstance *module_inst, uint32 seg_index,
 
 bool
 aot_data_drop(AOTModuleInstance *module_inst, uint32 seg_index);
+#endif
+
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+bool
+aot_signal_init();
+
+void
+aot_signal_destroy();
 #endif
 
 #ifdef __cplusplus

--- a/core/iwasm/common/wasm_exec_env.c
+++ b/core/iwasm/common/wasm_exec_env.c
@@ -61,6 +61,15 @@ fail1:
 void
 wasm_exec_env_destroy_internal(WASMExecEnv *exec_env)
 {
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    WASMJmpBuf *jmpbuf = exec_env->jmpbuf_stack_top;
+    WASMJmpBuf *jmpbuf_prev;
+    while (jmpbuf) {
+        jmpbuf_prev = jmpbuf->prev;
+        wasm_runtime_free(jmpbuf);
+        jmpbuf = jmpbuf_prev;
+    }
+#endif
 #if WASM_ENABLE_THREAD_MGR != 0
     os_mutex_destroy(&exec_env->wait_lock);
     os_cond_destroy(&exec_env->wait_cond);
@@ -121,7 +130,6 @@ wasm_exec_env_set_thread_info(WASMExecEnv *exec_env)
     exec_env->handle = os_self_thread();
     exec_env->native_stack_boundary = os_thread_get_stack_boundary()
                                       + RESERVED_BYTES_TO_NATIVE_STACK_BOUNDARY;
-
 }
 
 #if WASM_ENABLE_THREAD_MGR != 0
@@ -137,3 +145,26 @@ wasm_exec_env_set_thread_arg(WASMExecEnv *exec_env, void *thread_arg)
     exec_env->thread_arg = thread_arg;
 }
 #endif
+
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+void
+wasm_exec_env_push_jmpbuf(WASMExecEnv *exec_env, WASMJmpBuf *jmpbuf)
+{
+    jmpbuf->prev = exec_env->jmpbuf_stack_top;
+    exec_env->jmpbuf_stack_top = jmpbuf;
+}
+
+WASMJmpBuf *
+wasm_exec_env_pop_jmpbuf(WASMExecEnv *exec_env)
+{
+    WASMJmpBuf *stack_top = exec_env->jmpbuf_stack_top;
+
+    if (stack_top) {
+        exec_env->jmpbuf_stack_top = stack_top->prev;
+        return stack_top;
+    }
+
+    return NULL;
+}
+#endif
+

--- a/core/iwasm/common/wasm_exec_env.h
+++ b/core/iwasm/common/wasm_exec_env.h
@@ -22,6 +22,13 @@ struct WASMInterpFrame;
 typedef struct WASMCluster WASMCluster;
 #endif
 
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+typedef struct WASMJmpBuf {
+    struct WASMJmpBuf *prev;
+    korp_jmpbuf jmpbuf;
+} WASMJmpBuf;
+#endif
+
 /* Execution environment */
 typedef struct WASMExecEnv {
     /* Next thread's exec env of a WASM module instance. */
@@ -80,6 +87,10 @@ typedef struct WASMExecEnv {
 
 #if WASM_ENABLE_INTERP != 0
     BlockAddr block_addr_cache[BLOCK_ADDR_CACHE_SIZE][BLOCK_ADDR_CONFLICT_SIZE];
+#endif
+
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    WASMJmpBuf *jmpbuf_stack_top;
 #endif
 
     /* The WASM stack size */
@@ -205,6 +216,14 @@ wasm_exec_env_get_thread_arg(WASMExecEnv *exec_env);
 
 void
 wasm_exec_env_set_thread_arg(WASMExecEnv *exec_env, void *thread_arg);
+#endif
+
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+void
+wasm_exec_env_push_jmpbuf(WASMExecEnv *exec_env, WASMJmpBuf *jmpbuf);
+
+WASMJmpBuf *
+wasm_exec_env_pop_jmpbuf(WASMExecEnv *exec_env);
 #endif
 
 #ifdef __cplusplus

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -120,9 +120,24 @@ wasm_runtime_env_init()
         goto fail5;
     }
 #endif
+
+#if WASM_ENABLE_AOT != 0
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    if (!aot_signal_init()) {
+        goto fail6;
+    }
+#endif
+#endif
+
     return true;
 
+#if WASM_ENABLE_AOT != 0
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+fail6:
+#endif
+#endif
 #if WASM_ENABLE_THREAD_MGR != 0
+    thread_manager_destroy();
 fail5:
 #endif
 #if WASM_ENABLE_SHARED_MEMORY
@@ -170,6 +185,12 @@ wasm_runtime_init()
 void
 wasm_runtime_destroy()
 {
+#if WASM_ENABLE_AOT != 0
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    aot_signal_destroy();
+#endif
+#endif
+
     /* runtime env destroy */
 #if WASM_ENABLE_MULTI_MODULE
     wasm_runtime_destroy_loading_module_list();

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -398,7 +398,8 @@ aot_compile_op_call(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         aot_func = func_ctxes[func_idx - import_func_count]->aot_func;
         callee_cell_num = aot_func->param_cell_num + aot_func->local_cell_num + 1;
 
-        if (!check_stack_boundary(comp_ctx, func_ctx, callee_cell_num))
+        if (comp_ctx->enable_bound_check
+            && !check_stack_boundary(comp_ctx, func_ctx, callee_cell_num))
             goto fail;
 
         /* Call the function */

--- a/core/iwasm/compilation/aot_emit_memory.c
+++ b/core/iwasm/compilation/aot_emit_memory.c
@@ -75,18 +75,13 @@ check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                       uint32 offset, uint32 bytes)
 {
     LLVMValueRef offset_const = I32_CONST(offset);
-    LLVMValueRef bytes_const = I32_CONST(bytes);
-    LLVMValueRef bytes64_const = I64_CONST(bytes);
-    LLVMValueRef heap_base_offset = func_ctx->heap_base_offset;
-    LLVMValueRef addr, maddr, offset1, offset2, cmp;
-    LLVMValueRef mem_base_addr, mem_check_bound, total_mem_size;
+    LLVMValueRef addr, maddr, offset1, cmp, cmp1, cmp2;
+    LLVMValueRef mem_base_addr, mem_check_bound;
     LLVMBasicBlockRef block_curr = LLVMGetInsertBlock(comp_ctx->builder);
-    LLVMBasicBlockRef check_succ, check_mem_space;
+    LLVMBasicBlockRef check_succ;
     AOTValue *aot_value;
 
     CHECK_LLVM_CONST(offset_const);
-    CHECK_LLVM_CONST(bytes_const);
-    CHECK_LLVM_CONST(bytes64_const);
 
     /* Get memory base address and memory data size */
     if (func_ctx->mem_space_unchanged) {
@@ -104,21 +99,20 @@ check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     aot_value = func_ctx->block_stack.block_list_end->value_stack.value_list_end;
 
     POP_I32(addr);
-    /* offset1 = offset + addr; */
-    BUILD_OP(Add, offset_const, addr, offset1, "offset1");
 
     /* return addres directly if constant offset and inside memory space */
-    if (LLVMIsConstant(offset1)) {
-        uint32 mem_offset = (uint32)LLVMConstIntGetZExtValue(offset1);
+    if (LLVMIsConstant(addr)) {
+        int64 mem_offset = (int64)LLVMConstIntGetSExtValue(addr) + (int64)offset;
         uint32 num_bytes_per_page = comp_ctx->comp_data->num_bytes_per_page;
         uint32 init_page_count = comp_ctx->comp_data->mem_init_page_count;
-        uint32 mem_data_size = num_bytes_per_page * init_page_count;
+        int64 mem_data_size = num_bytes_per_page * init_page_count;
         if (mem_data_size > 0
+            && mem_offset >= 0
             && mem_offset <= mem_data_size - bytes) {
             /* inside memory space */
-            /* maddr = mem_base_addr + moffset */
-            if (!(maddr = LLVMBuildInBoundsGEP(comp_ctx->builder,
-                                               mem_base_addr,
+            offset1 = I32_CONST((uint32)mem_offset);
+            CHECK_LLVM_CONST(offset_const);
+            if (!(maddr = LLVMBuildInBoundsGEP(comp_ctx->builder, mem_base_addr,
                                                &offset1, 1, "maddr"))) {
                 aot_set_last_error("llvm build add failed.");
                 goto fail;
@@ -127,51 +121,35 @@ check_memory_overflow(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         }
     }
 
-    if (comp_ctx->comp_data->mem_init_page_count == 0) {
-        /* Get total memory size */
-        if (func_ctx->mem_space_unchanged) {
-            total_mem_size = func_ctx->total_mem_size;
-        }
-        else {
-            if (!(total_mem_size = LLVMBuildLoad(comp_ctx->builder,
-                                                 func_ctx->total_mem_size,
-                                                 "total_mem_size"))) {
-                aot_set_last_error("llvm build load failed.");
+    if (!(offset_const = LLVMBuildZExt(comp_ctx->builder, offset_const,
+                                       I64_TYPE, "offset_i64"))
+        || !(addr = LLVMBuildSExt(comp_ctx->builder, addr,
+                                  I64_TYPE, "addr_i64"))) {
+                aot_set_last_error("llvm build extend i32 to i64 failed.");
                 goto fail;
-            }
-        }
-
-        ADD_BASIC_BLOCK(check_mem_space, "check_mem_space");
-        LLVMMoveBasicBlockAfter(check_mem_space, block_curr);
-
-        /* if total_mem_size is zero, boundary check fail */
-        BUILD_ICMP(LLVMIntEQ, total_mem_size, I32_ZERO, cmp,
-                   "cmp_total_mem_size");
-        if (!aot_emit_exception(comp_ctx, func_ctx,
-                                EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS,
-                                true, cmp, check_mem_space)) {
-            goto fail;
-        }
-        SET_BUILD_POS(check_mem_space);
     }
 
-    if (!(aot_value->is_local
-          && aot_checked_addr_list_find(func_ctx, aot_value->local_idx,
-                                        offset, bytes))) {
-        /* offset2 = offset1 - heap_base_offset; */
-        BUILD_OP(Sub, offset1, heap_base_offset, offset2, "offset2");
+    /* offset1 = offset + addr; */
+    BUILD_OP(Add, offset_const, addr, offset1, "offset1");
 
+    if (comp_ctx->enable_bound_check
+        && !(aot_value->is_local
+             && aot_checked_addr_list_find(func_ctx, aot_value->local_idx,
+                                           offset, bytes))) {
         if (!(mem_check_bound =
                     get_memory_check_bound(comp_ctx, func_ctx, bytes))) {
             goto fail;
         }
 
+        BUILD_ICMP(LLVMIntSGT, func_ctx->mem_bound_check_heap_base, offset1,
+                   cmp1, "cmp1");
+        BUILD_ICMP(LLVMIntSGT, offset1, mem_check_bound, cmp2, "cmp2");
+        BUILD_OP(Or, cmp1, cmp2, cmp, "cmp");
+
         /* Add basic blocks */
         ADD_BASIC_BLOCK(check_succ, "check_succ");
         LLVMMoveBasicBlockAfter(check_succ, block_curr);
 
-        /* offset2 > bound ? */
-        BUILD_ICMP(LLVMIntUGT, offset2, mem_check_bound, cmp, "cmp");
         if (!aot_emit_exception(comp_ctx, func_ctx,
                                 EXCE_OUT_OF_BOUNDS_MEMORY_ACCESS,
                                 true, cmp, check_succ)) {

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -105,9 +105,8 @@ typedef struct AOTFuncContext {
   LLVMValueRef native_stack_bound;
   LLVMValueRef last_alloca;
 
-  LLVMValueRef heap_base_offset;
   LLVMValueRef mem_base_addr;
-  LLVMValueRef total_mem_size;
+  LLVMValueRef mem_bound_check_heap_base;
   LLVMValueRef mem_bound_check_1byte;
   LLVMValueRef mem_bound_check_2bytes;
   LLVMValueRef mem_bound_check_4bytes;
@@ -188,6 +187,9 @@ typedef struct AOTCompContext {
   /* Bulk memory feature */
   bool enable_bulk_memory;
 
+  /* Bounday Check */
+  bool enable_bound_check;
+
   /* Whether optimize the JITed code */
   bool optimize;
 
@@ -227,9 +229,11 @@ typedef struct AOTCompOption{
     char *target_cpu;
     char *cpu_features;
     bool enable_bulk_memory;
+    bool is_sgx_platform;
     uint32 opt_level;
     uint32 size_level;
     uint32 output_format;
+    uint32 bounds_checks;
 } AOTCompOption, *aot_comp_option_t;
 
 AOTCompContext *

--- a/core/iwasm/include/aot_export.h
+++ b/core/iwasm/include/aot_export.h
@@ -40,9 +40,11 @@ typedef struct AOTCompOption{
     char *target_cpu;
     char *cpu_features;
     bool enable_bulk_memory;
+    bool is_sgx_platform;
     uint32_t opt_level;
     uint32_t size_level;
     uint32_t output_format;
+    uint32_t bounds_checks;
 } AOTCompOption, *aot_comp_option_t;
 
 aot_comp_context_t

--- a/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
+++ b/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
@@ -483,6 +483,7 @@ pthread_start_routine(void *arg)
         return NULL;
     }
 
+    wasm_exec_env_set_thread_info(exec_env);
     argv[0] = addr_native_to_app(routine_args->arg);
 
     if(!wasm_runtime_call_indirect(exec_env,

--- a/core/shared/platform/alios/alios_platform.c
+++ b/core/shared/platform/alios/alios_platform.c
@@ -42,19 +42,21 @@ os_free(void *ptr)
 }
 
 void *
-os_mmap(void *hint, unsigned int size, int prot, int flags)
+os_mmap(void *hint, size_t size, int prot, int flags)
 {
-    return BH_MALLOC(size);
+    if ((uint64)size >= UINT32_MAX)
+        return NULL;
+    return BH_MALLOC((uint32)size);
 }
 
 void
-os_munmap(void *addr, uint32 size)
+os_munmap(void *addr, size_t size)
 {
     return BH_FREE(addr);
 }
 
 int
-os_mprotect(void *addr, uint32 size, int prot)
+os_mprotect(void *addr, size_t size, int prot)
 {
     return 0;
 }

--- a/core/shared/platform/android/platform_internal.h
+++ b/core/shared/platform/android/platform_internal.h
@@ -48,6 +48,38 @@ typedef pthread_mutex_t korp_mutex;
 typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
 
+#if WASM_DISABLE_HW_BOUND_CHECK == 0
+#if defined(BUILD_TARGET_X86_64) \
+    || defined(BUILD_TARGET_AMD_64) \
+    || defined(BUILD_TARGET_AARCH64)
+
+#include <signal.h>
+#include <setjmp.h>
+
+#define OS_ENABLE_HW_BOUND_CHECK
+
+#define os_thread_local_attribute __thread
+
+typedef jmp_buf korp_jmpbuf;
+
+#define os_setjmp setjmp
+#define os_longjmp longjmp
+#define os_alloca alloca
+
+#define os_getpagesize getpagesize
+
+typedef void (*os_signal_handler)(void *sig_addr);
+
+int os_signal_init(os_signal_handler handler);
+
+void os_signal_destroy();
+
+void os_signal_unmask();
+
+void os_sigreturn();
+#endif /* end of BUILD_TARGET_X86_64/AMD_64/AARCH64 */
+#endif /* end of WASM_DISABLE_HW_BOUND_CHECK */
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/shared/platform/common/posix/posix_thread.c
+++ b/core/shared/platform/common/posix/posix_thread.c
@@ -21,7 +21,7 @@ static void *os_thread_wrapper(void *arg)
     thread_wrapper_arg * targ = arg;
     thread_start_routine_t start_func = targ->start;
     void *thread_arg = targ->arg;
-    printf("THREAD CREATE %p\n", &targ);
+    os_printf("THREAD CREATED %p\n", &targ);
     targ->stack = (void *)((uintptr_t)(&arg) & (uintptr_t)~0xfff);
     BH_FREE(targ);
     start_func(thread_arg);
@@ -41,8 +41,8 @@ int os_thread_create_with_prio(korp_tid *tid, thread_start_routine_t start,
     pthread_attr_init(&tattr);
     pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_JOINABLE);
     if (pthread_attr_setstacksize(&tattr, stack_size) != 0) {
-        printf("Invalid thread stack size %u. Min stack size on Linux = %u",
-               stack_size, PTHREAD_STACK_MIN);
+        os_printf("Invalid thread stack size %u. Min stack size on Linux = %u",
+                  stack_size, PTHREAD_STACK_MIN);
         pthread_attr_destroy(&tattr);
         return BHT_ERROR;
     }
@@ -123,7 +123,7 @@ int os_mutex_lock(korp_mutex *mutex)
     assert(mutex);
     ret = pthread_mutex_lock(mutex);
     if (0 != ret) {
-        printf("vm mutex lock failed (ret=%d)!\n", ret);
+        os_printf("vm mutex lock failed (ret=%d)!\n", ret);
         exit(-1);
     }
     return ret;
@@ -140,7 +140,7 @@ int os_mutex_unlock(korp_mutex *mutex)
     assert(mutex);
     ret = pthread_mutex_unlock(mutex);
     if (0 != ret) {
-        printf("vm mutex unlock failed (ret=%d)!\n", ret);
+        os_printf("vm mutex unlock failed (ret=%d)!\n", ret);
         exit(-1);
     }
     return ret;
@@ -241,15 +241,16 @@ uint8 *os_thread_get_stack_boundary()
     pthread_attr_t attr;
     uint8 *addr = NULL;
     size_t stack_size, guard_size;
+    int page_size = getpagesize();
 
 #ifdef __linux__
     if (pthread_getattr_np(self, &attr) == 0) {
         pthread_attr_getstack(&attr, (void**)&addr, &stack_size);
         pthread_attr_getguardsize(&attr, &guard_size);
         pthread_attr_destroy(&attr);
-        if (guard_size < 4 * 1024)
-            /* Reserved 4 KB guard size at least for safety */
-            guard_size = 4 * 1024;
+        if (guard_size < (size_t)page_size)
+            /* Reserved 1 guard page at least for safety */
+            guard_size = (size_t)page_size;
         addr += guard_size;
     }
     (void)stack_size;
@@ -257,10 +258,150 @@ uint8 *os_thread_get_stack_boundary()
     if ((addr = (uint8*)pthread_get_stackaddr_np(self))) {
         stack_size = pthread_get_stacksize_np(self);
         addr -= stack_size;
-        /* Reserved 4 KB guard size at least for safety */
-        addr += 4 * 1024;
+        /* Reserved 1 guard page at least for safety */
+        addr += page_size;
     }
 #endif
 
     return addr;
 }
+
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+
+#define SIG_ALT_STACK_SIZE (32 * 1024)
+
+/* The signal alternate stack base addr */
+static uint8 *sigalt_stack_base_addr;
+
+/* The signal handler passed to os_signal_init() */
+static os_signal_handler signal_handler;
+
+static void
+mask_signals(int how)
+{
+    sigset_t set;
+
+    sigemptyset(&set);
+    sigaddset(&set, SIGSEGV);
+    sigaddset(&set, SIGBUS);
+    pthread_sigmask(how, &set, NULL);
+}
+
+__attribute__((noreturn)) static void
+signal_callback(int sig_num, siginfo_t *sig_info, void *sig_ucontext)
+{
+    int i;
+    void *sig_addr = sig_info->si_addr;
+
+    mask_signals(SIG_BLOCK);
+
+    if (signal_handler
+        && (sig_num == SIGSEGV || sig_num == SIGBUS)) {
+        signal_handler(sig_addr);
+    }
+
+    /* signal unhandled */
+    switch (sig_num) {
+        case SIGSEGV:
+            os_printf("unhandled SIGSEGV, si_addr: %p\n", sig_addr);
+            break;
+        case SIGBUS:
+            os_printf("unhandled SIGBUS, si_addr: %p\n", sig_addr);
+            break;
+        default:
+            os_printf("unhandle signal %d, si_addr: %p\n",
+                      sig_num, sig_addr);
+            break;
+    }
+
+    /* divived by 0 to make it abort */
+    i = os_printf(" ");
+    os_printf("%d\n", i / (i - 1));
+    /* access NULL ptr to make it abort */
+    os_printf("%d\n", *(uint32*)(uintptr_t)(i - 1));
+    exit(1);
+}
+
+int
+os_signal_init(os_signal_handler handler)
+{
+    int ret = -1;
+    struct sigaction sig_act;
+    stack_t sigalt_stack_info;
+    uint32 map_size = SIG_ALT_STACK_SIZE;
+    uint8 *map_addr;
+
+    /* Initialize memory for signal alternate stack */
+    if (!(map_addr = os_mmap(NULL, map_size,
+                             MMAP_PROT_READ | MMAP_PROT_WRITE,
+                             MMAP_MAP_NONE))) {
+        os_printf("Failed to mmap memory for alternate stack\n");
+        return -1;
+    }
+
+    /* Initialize signal alternate stack */
+    memset(map_addr, 0, map_size);
+    sigalt_stack_info.ss_sp = map_addr;
+    sigalt_stack_info.ss_size = map_size;
+    sigalt_stack_info.ss_flags = 0;
+    if ((ret = sigaltstack(&sigalt_stack_info, NULL)) != 0) {
+        goto fail1;
+    }
+
+    /* Install signal hanlder */
+    sig_act.sa_sigaction = signal_callback;
+    sig_act.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER;
+    sigemptyset(&sig_act.sa_mask);
+    if ((ret = sigaction(SIGSEGV, &sig_act, NULL)) != 0
+        || (ret = sigaction(SIGBUS, &sig_act, NULL)) != 0) {
+        goto fail2;
+    }
+
+    sigalt_stack_base_addr = map_addr;
+    signal_handler = handler;
+    return 0;
+
+fail2:
+    memset(&sigalt_stack_info, 0, sizeof(stack_t));
+    sigalt_stack_info.ss_flags = SS_DISABLE;
+    sigalt_stack_info.ss_size = map_size;
+    sigaltstack(&sigalt_stack_info, NULL);
+fail1:
+    os_munmap(map_addr, map_size);
+    return ret;
+}
+
+void
+os_signal_destroy()
+{
+    stack_t sigalt_stack_info;
+
+    /* Disable signal alternate stack */
+    memset(&sigalt_stack_info, 0, sizeof(stack_t));
+    sigalt_stack_info.ss_flags = SS_DISABLE;
+    sigalt_stack_info.ss_size = SIG_ALT_STACK_SIZE;
+    sigaltstack(&sigalt_stack_info, NULL);
+
+    os_munmap(sigalt_stack_base_addr, SIG_ALT_STACK_SIZE);
+}
+
+void
+os_signal_unmask()
+{
+    mask_signals(SIG_UNBLOCK);
+}
+
+void
+os_sigreturn()
+{
+#if defined(__APPLE__)
+    #define UC_RESET_ALT_STACK 0x80000000
+    extern int __sigreturn(void *, int);
+
+    /* It's necessary to call __sigreturn to restore the sigaltstack state
+       after exiting the signal handler. */
+    __sigreturn(NULL, UC_RESET_ALT_STACK);
+#endif
+}
+#endif /* end of OS_ENABLE_HW_BOUND_CHECK */
+

--- a/core/shared/platform/darwin/platform_internal.h
+++ b/core/shared/platform/darwin/platform_internal.h
@@ -51,6 +51,38 @@ typedef pthread_t korp_thread;
 #define os_printf printf
 #define os_vprintf vprintf
 
+#if WASM_DISABLE_HW_BOUND_CHECK == 0
+#if defined(BUILD_TARGET_X86_64) \
+    || defined(BUILD_TARGET_AMD_64) \
+    || defined(BUILD_TARGET_AARCH64)
+
+#include <signal.h>
+#include <setjmp.h>
+
+#define OS_ENABLE_HW_BOUND_CHECK
+
+#define os_thread_local_attribute __thread
+
+typedef jmp_buf korp_jmpbuf;
+
+#define os_setjmp setjmp
+#define os_longjmp longjmp
+#define os_alloca alloca
+
+#define os_getpagesize getpagesize
+
+typedef void (*os_signal_handler)(void *sig_addr);
+
+int os_signal_init(os_signal_handler handler);
+
+void os_signal_destroy();
+
+void os_signal_unmask();
+
+void os_sigreturn();
+#endif /* end of BUILD_TARGET_X86_64/AMD_64/AARCH64 */
+#endif /* end of WASM_DISABLE_HW_BOUND_CHECK */
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/shared/platform/include/platform_api_vmcore.h
+++ b/core/shared/platform/include/platform_api_vmcore.h
@@ -110,9 +110,9 @@ enum {
     MMAP_MAP_FIXED = 2
 };
 
-void *os_mmap(void *hint, unsigned int size, int prot, int flags);
-void os_munmap(void *addr, uint32 size);
-int os_mprotect(void *addr, uint32 size, int prot);
+void *os_mmap(void *hint, size_t size, int prot, int flags);
+void os_munmap(void *addr, size_t size);
+int os_mprotect(void *addr, size_t size, int prot);
 
 /**
  * Flush cpu data cache, in some CPUs, after applying relocation to the

--- a/core/shared/platform/linux/platform_internal.h
+++ b/core/shared/platform/linux/platform_internal.h
@@ -51,6 +51,38 @@ typedef pthread_t korp_thread;
 #define os_printf printf
 #define os_vprintf vprintf
 
+#if WASM_DISABLE_HW_BOUND_CHECK == 0
+#if defined(BUILD_TARGET_X86_64) \
+    || defined(BUILD_TARGET_AMD_64) \
+    || defined(BUILD_TARGET_AARCH64)
+
+#include <signal.h>
+#include <setjmp.h>
+
+#define OS_ENABLE_HW_BOUND_CHECK
+
+#define os_thread_local_attribute __thread
+
+typedef jmp_buf korp_jmpbuf;
+
+#define os_setjmp setjmp
+#define os_longjmp longjmp
+#define os_alloca alloca
+
+#define os_getpagesize getpagesize
+
+typedef void (*os_signal_handler)(void *sig_addr);
+
+int os_signal_init(os_signal_handler handler);
+
+void os_signal_destroy();
+
+void os_signal_unmask();
+
+void os_sigreturn();
+#endif /* end of BUILD_TARGET_X86_64/AMD_64/AARCH64 */
+#endif /* end of WASM_DISABLE_HW_BOUND_CHECK */
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/shared/platform/vxworks/platform_internal.h
+++ b/core/shared/platform/vxworks/platform_internal.h
@@ -50,6 +50,38 @@ typedef pthread_t korp_thread;
 #define os_printf printf
 #define os_vprintf vprintf
 
+#if WASM_DISABLE_HW_BOUND_CHECK == 0
+#if defined(BUILD_TARGET_X86_64) \
+    || defined(BUILD_TARGET_AMD_64) \
+    || defined(BUILD_TARGET_AARCH64)
+
+#include <signal.h>
+#include <setjmp.h>
+
+#define OS_ENABLE_HW_BOUND_CHECK
+
+#define os_thread_local_attribute __thread
+
+typedef jmp_buf korp_jmpbuf;
+
+#define os_setjmp setjmp
+#define os_longjmp longjmp
+#define os_alloca alloca
+
+#define os_getpagesize getpagesize
+
+typedef void (*os_signal_handler)(void *sig_addr);
+
+int os_signal_init(os_signal_handler handler);
+
+void os_signal_destroy();
+
+void os_signal_unmask();
+
+void os_sigreturn();
+#endif /* end of BUILD_TARGET_X86_64/AMD_64/AARCH64 */
+#endif /* end of WASM_DISABLE_HW_BOUND_CHECK */
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/shared/platform/zephyr/zephyr_platform.c
+++ b/core/shared/platform/zephyr/zephyr_platform.c
@@ -110,16 +110,18 @@ os_vprintf(const char *fmt, va_list ap)
 }
 
 void *
-os_mmap(void *hint, unsigned int size, int prot, int flags)
+os_mmap(void *hint, size_t size, int prot, int flags)
 {
+    if ((uint64)size >= UINT32_MAX)
+        return NULL;
     if (exec_mem_alloc_func)
-        return exec_mem_alloc_func(size);
+        return exec_mem_alloc_func((uint32)size);
     else
         return BH_MALLOC(size);
 }
 
 void
-os_munmap(void *addr, uint32 size)
+os_munmap(void *addr, size_t size)
 {
     if (exec_mem_free_func)
         exec_mem_free_func(addr);
@@ -128,7 +130,7 @@ os_munmap(void *addr, uint32 size)
 }
 
 int
-os_mprotect(void *addr, uint32 size, int prot)
+os_mprotect(void *addr, size_t size, int prot)
 {
     return 0;
 }

--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -46,7 +46,7 @@ The script `runtime_lib.cmake` defined a number of variables for configuring the
 
 - **WAMR_BUILD_LIBC_BUILTIN**=1/0,  default to enable if no set
 
-- **WAMR_BUILD_LIBC_WASI**=1/0, default to disable if no set
+- **WAMR_BUILD_LIBC_WASI**=1/0, default to enable if no set
 
 #### **Enable Multi-Module feature**
 
@@ -55,7 +55,7 @@ The script `runtime_lib.cmake` defined a number of variables for configuring the
 #### **Enable WASM mini loader**
 
 - **WAMR_BUILD_MINI_LOADER**=1/0, default to disable if not set
-Note: the mini loader doesn't check the integrity of the WASM binary file, user must ensure that the WASM file is not mal-formed.
+Note: the mini loader doesn't check the integrity of the WASM binary file, developer must ensure that the WASM file is not mal-formed.
 
 #### **Enable shared memory feature**
 - **WAMR_BUILD_SHARED_MEMORY**=1/0, default to disable if not set
@@ -63,9 +63,13 @@ Note: the mini loader doesn't check the integrity of the WASM binary file, user 
 #### **Enable thread manager**
 - **WAMR_BUILD_THREAD_MGR**=1/0, default to disable if not set
 
-#### **Enable Lib-pthread**
+#### **Enable lib-pthread**
 - **WAMR_BUILD_LIB_PTHREAD**=1/0, default to disable if not set
 > Note: The dependent feature of lib pthread such as the `shared memory` and `thread manager` will be enabled automatically.
+
+#### **Disable boundary check with hardware trap in AOT or JIT mode**
+- **WAMR_DISABLE_HW_BOUND_CHECK=1, default to enable if not set and supported by platform
+> Note: by default only platform linux/darwin/android/vxworks 64-bit will enable boundary check with hardware trap in AOT or JIT mode, and the wamrc tool will generate AOT code without boundary check instructions in all 64-bit targets except SGX to improve performance.
 
 **Combination of configurations:**
 

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -70,6 +70,10 @@ if (NOT DEFINED WAMR_BUILD_MINI_LOADER)
   set (WAMR_BUILD_MINI_LOADER 0)
 endif ()
 
+if (COLLECT_CODE_COVERAGE EQUAL 1)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
+endif ()
+
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include (${WAMR_ROOT_DIR}/build-scripts/runtime_lib.cmake)
@@ -109,4 +113,3 @@ install (TARGETS libiwasm DESTINATION lib)
 set_target_properties (libiwasm PROPERTIES OUTPUT_NAME iwasm)
 
 target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} -lm -ldl -lpthread)
-

--- a/wamr-compiler/CMakeLists.txt
+++ b/wamr-compiler/CMakeLists.txt
@@ -15,6 +15,7 @@ set (CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 add_definitions(-DWASM_ENABLE_INTERP=1)
 add_definitions(-DWASM_ENABLE_WAMR_COMPILER=1)
 add_definitions(-DWASM_ENABLE_BULK_MEMORY=1)
+add_definitions(-DWASM_DISABLE_HW_BOUND_CHECK=1)
 
 # Set WAMR_BUILD_TARGET, currently values supported:
 # "X86_64", "AMD_64", "X86_32", "ARM_32", "MIPS_32", "XTENSA_32"


### PR DESCRIPTION
Also implement native stack overflow check with hardware trap for 64-bit platforms
Refine classic interpreter and fast interpreter to improve performance
Update document