### PR TITLE
Refactor app heap and memory boundary check, and fix os_printf compilation error (#356)

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -176,9 +176,9 @@ memories_deinstantiate(AOTModuleInstance *module_inst)
 
             if (memory_inst->heap_data.ptr) {
 #ifndef OS_ENABLE_HW_BOUND_CHECK
-                wasm_runtime_free(memory_inst->heap_data.ptr);
+                wasm_runtime_free(memory_inst->memory_data.ptr);
 #else
-                os_munmap((uint8*)memory_inst->memory_data.ptr - 2 * (uint64)BH_GB,
+                os_munmap((uint8*)memory_inst->memory_data.ptr,
                           8 * (uint64)BH_GB);
 #endif
             }
@@ -193,19 +193,26 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
                    uint32 heap_size, char *error_buf, uint32 error_buf_size)
 {
     void *heap_handle;
-    uint64 memory_data_size = (uint64)memory->num_bytes_per_page
-                              * memory->mem_init_page_count;
-    uint64 total_size = heap_size + memory_data_size;
-    uint8 *p;
+    uint32 num_bytes_per_page = memory->num_bytes_per_page;
+    uint32 init_page_count = memory->mem_init_page_count;
+    uint32 max_page_count = memory->mem_max_page_count;
+    uint32 inc_page_count, aux_heap_base, global_idx;
+    uint32 bytes_of_last_page, bytes_to_page_end;
+    uint32 heap_offset = num_bytes_per_page *init_page_count;
+    uint64 total_size;
+    uint8 *p, *global_addr;
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    uint8 *mapped_mem;
+    uint64 map_size = 8 * (uint64)BH_GB;
+    uint64 page_size = os_getpagesize();
+#endif
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
-    AOTMemoryInstance *shared_memory_instance;
     bool is_shared_memory = memory->memory_flags & 0x02 ? true : false;
-    uint64 max_memory_data_size = (uint64)memory->num_bytes_per_page
-                                  * memory->mem_max_page_count;
 
     /* Shared memory */
     if (is_shared_memory) {
+        AOTMemoryInstance *shared_memory_instance;
         WASMSharedMemNode *node =
             wasm_module_get_shared_memory((WASMModuleCommon *)module);
         /* If the memory of this module has been instantiated,
@@ -219,16 +226,94 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
                     (AOTMemoryInstance *)shared_memory_get_memory_inst(node);
             bh_assert(shared_memory_instance);
 
-            /* Set the shared memory flag, so the runtime will get the
-                actual memory inst through module_inst->memories array */
-            memory_inst->is_shared = true;
             (void)ref_count;
             return shared_memory_instance;
         }
-#ifndef OS_ENABLE_HW_BOUND_CHECK
-        /* Allocate max page for shared memory */
-        total_size = heap_size + max_memory_data_size;
+    }
 #endif
+
+    if (heap_size > 0
+        && module->malloc_func_index != (uint32)-1
+        && module->free_func_index != (uint32)-1) {
+        /* Disable app heap, use malloc/free function exported
+           by wasm app to allocate/free memory instead */
+        heap_size = 0;
+    }
+
+    if (init_page_count == max_page_count && init_page_count == 1) {
+        /* If only one page and at most one page, we just append
+           the app heap to the end of linear memory, enlarge the
+           num_bytes_per_page, and don't change the page count*/
+        heap_offset = num_bytes_per_page;
+        num_bytes_per_page += heap_size;
+        if (num_bytes_per_page < heap_size) {
+            set_error_buf(error_buf, error_buf_size,
+                          "memory size must be at most 65536 pages (4GiB)");
+            return NULL;
+        }
+    }
+    else if (heap_size > 0) {
+        if (module->aux_heap_base_global_index != (uint32)-1
+            && module->aux_heap_base < num_bytes_per_page
+                                       * init_page_count) {
+            /* Insert app heap before __heap_base */
+            aux_heap_base = module->aux_heap_base;
+            bytes_of_last_page = aux_heap_base % num_bytes_per_page;
+            if (bytes_of_last_page == 0)
+                bytes_of_last_page = num_bytes_per_page;
+            bytes_to_page_end = num_bytes_per_page - bytes_of_last_page;
+            inc_page_count = (heap_size - bytes_to_page_end
+                              + num_bytes_per_page - 1) / num_bytes_per_page;
+            heap_offset = aux_heap_base;
+            aux_heap_base += heap_size;
+
+            bytes_of_last_page = aux_heap_base % num_bytes_per_page;
+            if (bytes_of_last_page == 0)
+                bytes_of_last_page = num_bytes_per_page;
+            bytes_to_page_end = num_bytes_per_page - bytes_of_last_page;
+            if (bytes_to_page_end < 1 * BH_KB) {
+                aux_heap_base += 1 * BH_KB;
+                inc_page_count++;
+            }
+
+            /* Adjust __heap_base global value */
+            global_idx = module->aux_heap_base_global_index
+                         - module->import_global_count;
+            global_addr = (uint8*)module_inst->global_data.ptr +
+                          module->globals[global_idx].data_offset;
+            *(uint32 *)global_addr = aux_heap_base;
+            LOG_VERBOSE("Reset __heap_base global to %u", aux_heap_base);
+        }
+        else {
+            /* Insert app heap before new page */
+            inc_page_count = (heap_size + num_bytes_per_page - 1)
+                             / num_bytes_per_page;
+            heap_offset = num_bytes_per_page * init_page_count;
+            heap_size = num_bytes_per_page * inc_page_count;
+            if (heap_size > 0)
+                heap_size -= 1 * BH_KB;
+        }
+        init_page_count += inc_page_count;
+        max_page_count += inc_page_count;
+        if (init_page_count > 65536) {
+            set_error_buf(error_buf, error_buf_size,
+                          "memory size must be at most 65536 pages (4GiB)");
+            return NULL;
+        }
+        if (max_page_count > 65536)
+            max_page_count = 65536;
+    }
+
+    LOG_VERBOSE("Memory instantiate:");
+    LOG_VERBOSE("  page bytes: %u, init pages: %u, max pages: %u",
+                num_bytes_per_page, init_page_count, max_page_count);
+    LOG_VERBOSE("  heap offset: %u, heap size: %d\n", heap_offset, heap_size);
+
+    total_size = (uint64)num_bytes_per_page * init_page_count;
+#if WASM_ENABLE_SHARED_MEMORY != 0
+    if (is_shared_memory) {
+        /* Allocate max page for shared memory */
+        total_size = (uint64)num_bytes_per_page * max_page_count;
     }
 #endif
 
@@ -238,24 +323,21 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
         return NULL;
     }
 #else
-    uint8 *mapped_mem;
-    uint64 map_size = 8 * (uint64)BH_GB;
+    total_size = (total_size + page_size - 1) & ~(page_size - 1);
 
-    /* Totally 8G is mapped, the opcode load/store address range is -2G to 6G:
-     * ea = i + memarg.offset
-     *   i is i32, the range is -2G to 2G
-     *   memarg.offset is u32, the range is 0 to 4G
-     * so the range of ea is -2G to 6G
+    /* Totally 8G is mapped, the opcode load/store address range is 0 to 8G:
+     *   ea = i + memarg.offset
+     * both i and memarg.offset are u32 in range 0 to 4G
+     * so the range of ea is 0 to 8G
      */
     if (total_size >= UINT32_MAX
-        || !(mapped_mem = os_mmap(NULL, map_size,
-                                  MMAP_PROT_NONE, MMAP_MAP_NONE))) {
+        || !(p = mapped_mem = os_mmap(NULL, map_size,
+                                      MMAP_PROT_NONE, MMAP_MAP_NONE))) {
         set_error_buf(error_buf, error_buf_size,
                       "AOT module instantiate failed: mmap memory failed.");
         return NULL;
     }
 
-    p = mapped_mem + 2 * (uint64)BH_GB - heap_size;
     if (os_mprotect(p, total_size, MMAP_PROT_READ | MMAP_PROT_WRITE) != 0) {
         set_error_buf(error_buf, error_buf_size,
                       "AOT module instantiate failed: mprotec memory failed.");
@@ -263,15 +345,21 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
         return NULL;
     }
     memset(p, 0, (uint32)total_size);
-#endif
+#endif /* end of OS_ENABLE_HW_BOUND_CHECK */
 
     memory_inst->module_type = Wasm_Module_AoT;
+    memory_inst->num_bytes_per_page = num_bytes_per_page;
+    memory_inst->cur_page_count = init_page_count;
+    memory_inst->max_page_count = max_page_count;
+
+    /* Init memory info */
+    memory_inst->memory_data.ptr = p;
+    memory_inst->memory_data_end.ptr = p + (uint32)total_size;
+    memory_inst->memory_data_size = (uint32)total_size;
+
     /* Initialize heap info */
-    memory_inst->heap_data.ptr = p;
-    p += heap_size;
-    memory_inst->heap_data_end.ptr = p;
-    memory_inst->heap_data_size = heap_size;
-    memory_inst->heap_base_offset = -(int32)heap_size;
+    memory_inst->heap_data.ptr = p + heap_offset;
+    memory_inst->heap_data_end.ptr = p + heap_offset + heap_size;
     if (heap_size > 0) {
         if (!(heap_handle = mem_allocator_create(memory_inst->heap_data.ptr,
                                                  heap_size))) {
@@ -283,31 +371,20 @@ memory_instantiate(AOTModuleInstance *module_inst, AOTModule *module,
         memory_inst->heap_handle.ptr = heap_handle;
     }
 
-    /* Init memory info */
-    memory_inst->memory_data.ptr = p;
-#if WASM_ENABLE_SHARED_MEMORY != 0
-    if (is_shared_memory) {
-        p += (uint32)max_memory_data_size;
+    if (total_size > 0) {
+       if (sizeof(uintptr_t) == sizeof(uint64)) {
+           memory_inst->mem_bound_check_1byte.u64 = total_size - 1;
+           memory_inst->mem_bound_check_2bytes.u64 = total_size - 2;
+           memory_inst->mem_bound_check_4bytes.u64 = total_size - 4;
+           memory_inst->mem_bound_check_8bytes.u64 = total_size - 8;
+       }
+       else {
+           memory_inst->mem_bound_check_1byte.u32[0] = (uint32)total_size - 1;
+           memory_inst->mem_bound_check_2bytes.u32[0] = (uint32)total_size - 2;
+           memory_inst->mem_bound_check_4bytes.u32[0] = (uint32)total_size - 4;
+           memory_inst->mem_bound_check_8bytes.u32[0] = (uint32)total_size - 8;
+       }
     }
-    else
-#endif
-    {
-        p += (uint32)memory_data_size;
-    }
-    memory_inst->memory_data_end.ptr = p;
-    memory_inst->memory_data_size = (uint32)memory_data_size;
-    memory_inst->mem_cur_page_count = memory->mem_init_page_count;
-    memory_inst->mem_max_page_count = memory->mem_max_page_count;
-
-    memory_inst->mem_bound_check_heap_base = memory_inst->heap_base_offset;
-    memory_inst->mem_bound_check_1byte =
-                (int64)memory_inst->memory_data_size - 1;
-    memory_inst->mem_bound_check_2bytes =
-                (int64)memory_inst->memory_data_size - 2;
-    memory_inst->mem_bound_check_4bytes =
-                (int64)memory_inst->memory_data_size - 4;
-    memory_inst->mem_bound_check_8bytes =
-                (int64)memory_inst->memory_data_size - 8;
 
 #if WASM_ENABLE_SHARED_MEMORY != 0
     if (is_shared_memory) {
@@ -333,11 +410,11 @@ fail2:
 #endif
 fail1:
 #ifndef OS_ENABLE_HW_BOUND_CHECK
-    wasm_runtime_free(memory_inst->heap_data.ptr);
+    wasm_runtime_free(memory_inst->memory_data.ptr);
 #else
     os_munmap(mapped_mem, map_size);
 #endif
-    memory_inst->heap_data.ptr = NULL;
+    memory_inst->memory_data.ptr = NULL;
     return NULL;
 }
 
@@ -632,9 +709,6 @@ aot_instantiate(AOTModule *module, bool is_sub_inst,
     heap_size = align_uint(heap_size, 8);
     if (heap_size > APP_HEAP_SIZE_MAX)
         heap_size = APP_HEAP_SIZE_MAX;
-#ifdef OS_ENABLE_HW_BOUND_CHECK
-    heap_size = align_uint(heap_size, os_getpagesize());
-#endif
 
     /* Allocate module instance, global data, table data and heap data */
     if (!(module_inst = runtime_malloc(total_size,
@@ -829,10 +903,9 @@ aot_signal_handler(void *sig_addr)
         /* Get the default memory instance */
         memory_inst = aot_get_default_memory(module_inst);
         if (memory_inst) {
-            mapped_mem_start_addr = (uint8*)memory_inst->memory_data.ptr
-                                    - 2 * (uint64)BH_GB;
+            mapped_mem_start_addr = (uint8*)memory_inst->memory_data.ptr;
             mapped_mem_end_addr = (uint8*)memory_inst->memory_data.ptr
-                                  + 6 * (uint64)BH_GB;
+                                  + 8 * (uint64)BH_GB;
         }
 
         /* Get stack info of current thread */
@@ -1147,12 +1220,82 @@ aot_clear_exception(AOTModuleInstance *module_inst)
     module_inst->cur_exception[0] = '\0';
 }
 
+static bool
+execute_malloc_function(AOTModuleInstance *module_inst,
+                        AOTFunctionInstance *malloc_func,
+                        uint32 size, uint32 *p_result)
+{
+    uint32 argv[2];
+    bool ret;
+
+    argv[0] = size;
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    if (aot_exec_env != NULL) {
+        bh_assert(aot_exec_env->module_inst
+                  == (WASMModuleInstanceCommon *)module_inst);
+        ret = aot_call_function(aot_exec_env, malloc_func, 1, argv);
+    }
+    else
+#endif
+    {
+        ret = aot_create_exec_env_and_call_function
+                                (module_inst, malloc_func, 1, argv);
+    }
+
+    if (ret)
+        *p_result = argv[0];
+    return ret;
+}
+
+static bool
+execute_free_function(AOTModuleInstance *module_inst,
+                      AOTFunctionInstance *free_func,
+                      uint32 offset)
+{
+    uint32 argv[2];
+
+    argv[0] = offset;
+#ifdef OS_ENABLE_HW_BOUND_CHECK
+    if (aot_exec_env != NULL) {
+        bh_assert(aot_exec_env->module_inst
+                  == (WASMModuleInstanceCommon *)module_inst);
+        return aot_call_function(aot_exec_env, free_func, 1, argv);
+    }
+    else
+#endif
+    {
+        return aot_create_exec_env_and_call_function
+                            (module_inst, free_func, 1, argv);
+    }
+}
+
 int32
 aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
                   void **p_native_addr)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
-    uint8 *addr = mem_allocator_malloc(memory_inst->heap_handle.ptr, size);
+    AOTModule *module = (AOTModule *)module_inst->aot_module.ptr;
+    uint8 *addr = NULL;
+    uint32 offset = 0;
+
+    if (memory_inst->heap_handle.ptr) {
+        addr = mem_allocator_malloc(memory_inst->heap_handle.ptr, size);
+    }
+    else if (module->malloc_func_index != (uint32)-1
+             && module->free_func_index != (uint32)-1) {
+        AOTFunctionInstance *malloc_func =
+            aot_lookup_function(module_inst, "malloc", "(i)i");
+
+        bh_assert(malloc_func);
+        if (!execute_malloc_function(module_inst, malloc_func,
+                                     size, &offset)) {
+            return 0;
+        }
+        addr = offset
+               ? (uint8*)memory_inst->memory_data.ptr + offset
+               : NULL;
+    }
+
     if (!addr) {
         aot_set_exception(module_inst, "out of memory");
         return 0;
@@ -1166,11 +1309,25 @@ void
 aot_module_free(AOTModuleInstance *module_inst, int32 ptr)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
+    AOTModule *module = (AOTModule *)module_inst->aot_module.ptr;
+
     if (ptr) {
-        uint8 *addr = (uint8*)memory_inst->memory_data.ptr + ptr;
-        if ((uint8*)memory_inst->heap_data.ptr < addr
-            && addr < (uint8*)memory_inst->memory_data.ptr)
+        uint8 *addr = (uint8 *)memory_inst->memory_data.ptr + ptr;
+        if (memory_inst->heap_handle.ptr
+            &&(uint8 *)memory_inst->heap_data.ptr < addr
+            && addr < (uint8 *)memory_inst->heap_data_end.ptr) {
             mem_allocator_free(memory_inst->heap_handle.ptr, addr);
+        }
+        else if (module->malloc_func_index != (uint32)-1
+                 && module->free_func_index != (uint32)-1
+                 && (uint8 *)memory_inst->memory_data.ptr <= addr
+                 && addr < (uint8 *)memory_inst->memory_data_end.ptr) {
+            AOTFunctionInstance *free_func =
+                aot_lookup_function(module_inst, "free", "(i)i");
+
+            bh_assert(free_func);
+            execute_free_function(module_inst, free_func, (uint32)ptr);
+        }
     }
 }
 
@@ -1184,7 +1341,7 @@ aot_module_dup_data(AOTModuleInstance *module_inst,
 
     if (buffer_offset != 0) {
         buffer = aot_addr_app_to_native(module_inst, buffer_offset);
-        memcpy(buffer, src, size);
+        bh_memcpy_s(buffer, size, src, size);
     }
     return buffer_offset;
 }
@@ -1194,13 +1351,12 @@ aot_validate_app_addr(AOTModuleInstance *module_inst,
                       int32 app_offset, uint32 size)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
+
     /* integer overflow check */
-    if(app_offset + (int32)size < app_offset) {
+    if((uint32)app_offset + size < (uint32)app_offset) {
         goto fail;
     }
-
-    if (memory_inst->heap_base_offset <= app_offset
-        && app_offset + (int32)size <= (int32)memory_inst->memory_data_size) {
+    if ((uint32)app_offset + size <= memory_inst->memory_data_size) {
         return true;
     }
 fail:
@@ -1212,20 +1368,17 @@ bool
 aot_validate_native_addr(AOTModuleInstance *module_inst,
                          void *native_ptr, uint32 size)
 {
-    uint8 *addr = (uint8*)native_ptr;
+    uint8 *addr = (uint8 *)native_ptr;
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
-    int32 memory_data_size = (int32)memory_inst->memory_data_size;
 
     /* integer overflow check */
     if (addr + size < addr) {
         goto fail;
     }
 
-    if ((uint8*)memory_inst->heap_data.ptr <= addr
-        && addr + size <= (uint8*)memory_inst->memory_data.ptr
-                          + memory_data_size) {
+    if ((uint8 *)memory_inst->memory_data.ptr <= addr
+        && addr + size <= (uint8 *)memory_inst->memory_data_end.ptr)
         return true;
-    }
 fail:
     aot_set_exception(module_inst, "out of bounds memory access");
     return false;
@@ -1235,12 +1388,10 @@ void *
 aot_addr_app_to_native(AOTModuleInstance *module_inst, int32 app_offset)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
-    int32 memory_data_size = (int32)memory_inst->memory_data_size;
-    uint8 *addr = (uint8 *)memory_inst->memory_data.ptr + app_offset;
+    uint8 *addr = (uint8 *)memory_inst->memory_data.ptr + (uint32)app_offset;
 
-    if ((uint8*)memory_inst->heap_data.ptr <= addr
-        && addr < (uint8*)memory_inst->memory_data.ptr
-                  + memory_data_size)
+    if ((uint8 *)memory_inst->memory_data.ptr <= addr
+        && addr < (uint8 *)memory_inst->memory_data_end.ptr)
         return addr;
     return NULL;
 }
@@ -1248,14 +1399,12 @@ aot_addr_app_to_native(AOTModuleInstance *module_inst, int32 app_offset)
 int32
 aot_addr_native_to_app(AOTModuleInstance *module_inst, void *native_ptr)
 {
-    uint8 *addr = (uint8*)native_ptr;
+    uint8 *addr = (uint8 *)native_ptr;
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
-    int32 memory_data_size = (int32)memory_inst->memory_data_size;
 
-    if ((uint8*)memory_inst->heap_data.ptr <= addr
-        && addr < (uint8*)memory_inst->memory_data.ptr
-                  + memory_data_size)
-        return (int32)(addr - (uint8*)memory_inst->memory_data.ptr);
+    if ((uint8 *)memory_inst->memory_data.ptr <= addr
+        && addr < (uint8 *)memory_inst->memory_data_end.ptr)
+        return (int32)(addr - (uint8 *)memory_inst->memory_data.ptr);
     return 0;
 }
 
@@ -1266,14 +1415,13 @@ aot_get_app_addr_range(AOTModuleInstance *module_inst,
                        int32 *p_app_end_offset)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
-    int32 memory_data_size = (int32)memory_inst->memory_data_size;
+    uint32 memory_data_size = memory_inst->memory_data_size;
 
-    if (memory_inst->heap_base_offset <= app_offset
-        && app_offset < memory_data_size) {
+    if ((uint32)app_offset < memory_data_size) {
         if (p_app_start_offset)
-            *p_app_start_offset = memory_inst->heap_base_offset;
+            *p_app_start_offset = 0;
         if (p_app_end_offset)
-            *p_app_end_offset = memory_data_size;
+            *p_app_end_offset = (int32)memory_data_size;
         return true;
     }
     return false;
@@ -1285,18 +1433,15 @@ aot_get_native_addr_range(AOTModuleInstance *module_inst,
                           uint8 **p_native_start_addr,
                           uint8 **p_native_end_addr)
 {
-    uint8 *addr = (uint8*)native_ptr;
+    uint8 *addr = (uint8 *)native_ptr;
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
-    int32 memory_data_size = (int32)memory_inst->memory_data_size;
 
-    if ((uint8*)memory_inst->heap_data.ptr <= addr
-        && addr < (uint8*)memory_inst->memory_data.ptr
-                  + memory_data_size) {
+    if ((uint8 *)memory_inst->memory_data.ptr <= addr
+        && addr < (uint8 *)memory_inst->memory_data_end.ptr) {
         if (p_native_start_addr)
-            *p_native_start_addr = (uint8*)memory_inst->heap_data.ptr;
+            *p_native_start_addr = (uint8 *)memory_inst->memory_data.ptr;
         if (p_native_end_addr)
-            *p_native_end_addr = (uint8*)memory_inst->memory_data.ptr
-                                 + memory_data_size;
+            *p_native_end_addr = (uint8 *)memory_inst->memory_data_end.ptr;
         return true;
     }
     return false;
@@ -1307,17 +1452,17 @@ bool
 aot_enlarge_memory(AOTModuleInstance *module_inst, uint32 inc_page_count)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
-    uint8 *heap_data_old = memory_inst->heap_data.ptr, *heap_data;
-    uint32 num_bytes_per_page =
-        ((AOTModule*)module_inst->aot_module.ptr)->memories[0].num_bytes_per_page;
-    uint32 cur_page_count = memory_inst->mem_cur_page_count;
-    uint32 max_page_count = memory_inst->mem_max_page_count;
+    uint32 num_bytes_per_page = memory_inst->num_bytes_per_page;
+    uint32 cur_page_count = memory_inst->cur_page_count;
+    uint32 max_page_count = memory_inst->max_page_count;
     uint32 total_page_count = cur_page_count + inc_page_count;
-    uint64 memory_data_size = (uint64)num_bytes_per_page * total_page_count;
-    uint32 heap_size = (uint32)((uint8*)memory_inst->memory_data.ptr
-                                - (uint8*)memory_inst->heap_data.ptr);
-    uint32 total_size_old = heap_size + memory_inst->memory_data_size;
-    uint64 total_size = heap_size + memory_data_size;
+    uint32 total_size_old = memory_inst->memory_data_size;
+    uint64 total_size = (uint64)num_bytes_per_page * total_page_count;
+    uint32 heap_size = (uint32)((uint8 *)memory_inst->heap_data_end.ptr
+                                - (uint8 *)memory_inst->heap_data.ptr);
+    uint8 *memory_data_old = (uint8 *)memory_inst->memory_data.ptr;
+    uint8 *heap_data_old = (uint8 *)memory_inst->heap_data.ptr;
+    uint8 *memory_data, *heap_data;
     void *heap_handle_old = memory_inst->heap_handle.ptr;
 
     if (inc_page_count <= 0)
@@ -1339,7 +1484,7 @@ aot_enlarge_memory(AOTModuleInstance *module_inst, uint32 inc_page_count)
     if (memory_inst->is_shared) {
         /* For shared memory, we have reserved the maximum spaces during
             instantiate, only change the cur_page_count here */
-        memory_inst->mem_cur_page_count = total_page_count;
+        memory_inst->cur_page_count = total_page_count;
         return true;
     }
 #endif
@@ -1349,8 +1494,9 @@ aot_enlarge_memory(AOTModuleInstance *module_inst, uint32 inc_page_count)
            we cannot access its lock again. */
         mem_allocator_destroy_lock(memory_inst->heap_handle.ptr);
     }
-    if (!(heap_data = wasm_runtime_realloc(heap_data_old, (uint32)total_size))) {
-        if (!(heap_data = wasm_runtime_malloc((uint32)total_size))) {
+    if (!(memory_data = wasm_runtime_realloc(memory_data_old,
+                                             (uint32)total_size))) {
+        if (!(memory_data = wasm_runtime_malloc((uint32)total_size))) {
             if (heap_size > 0) {
                 /* Restore heap's lock if memory re-alloc failed */
                 mem_allocator_reinit_lock(memory_inst->heap_handle.ptr);
@@ -1358,20 +1504,22 @@ aot_enlarge_memory(AOTModuleInstance *module_inst, uint32 inc_page_count)
             aot_set_exception(module_inst, "fail to enlarge memory.");
             return false;
         }
-        bh_memcpy_s(heap_data, (uint32)total_size,
-                    heap_data_old, total_size_old);
-        wasm_runtime_free(heap_data_old);
+        bh_memcpy_s(memory_data, (uint32)total_size,
+                    memory_data_old, total_size_old);
+        wasm_runtime_free(memory_data_old);
     }
 
-    memset(heap_data + total_size_old,
+    memset(memory_data + total_size_old,
            0, (uint32)total_size - total_size_old);
 
-    memory_inst->heap_data.ptr = heap_data;
-    memory_inst->heap_data_end.ptr = heap_data + heap_size;
+    memory_inst->cur_page_count = total_page_count;
+    memory_inst->memory_data_size = (uint32)total_size;
+    memory_inst->memory_data.ptr = memory_data;
+    memory_inst->memory_data_end.ptr = memory_data + total_size;
 
     if (heap_size > 0) {
-        memory_inst->heap_handle.ptr = (uint8*)heap_handle_old
-                                       + (heap_data - heap_data_old);
+        memory_inst->heap_handle.ptr = (uint8 *)heap_handle_old
+                                       + (memory_data - memory_data_old);
         if (mem_allocator_migrate(memory_inst->heap_handle.ptr,
                                   heap_handle_old) != 0) {
             aot_set_exception(module_inst, "fail to enlarge memory.");
@@ -1379,29 +1527,34 @@ aot_enlarge_memory(AOTModuleInstance *module_inst, uint32 inc_page_count)
         }
     }
 
-    memory_inst->mem_cur_page_count = total_page_count;
-    memory_inst->memory_data_size = (uint32)memory_data_size;
-    memory_inst->memory_data.ptr = (uint8*)heap_data + heap_size;
-    memory_inst->memory_data_end.ptr = (uint8*)memory_inst->memory_data.ptr
-                                       + (uint32)memory_data_size;
+    heap_data = heap_data_old + (memory_data - memory_data_old);
+    memory_inst->heap_data.ptr = heap_data;
+    memory_inst->heap_data_end.ptr = heap_data + heap_size;
 
-    memory_inst->mem_bound_check_1byte = memory_inst->memory_data_size - 1;
-    memory_inst->mem_bound_check_2bytes = memory_inst->memory_data_size - 2;
-    memory_inst->mem_bound_check_4bytes = memory_inst->memory_data_size - 4;
-    memory_inst->mem_bound_check_8bytes = memory_inst->memory_data_size - 8;
+    if (sizeof(uintptr_t) == sizeof(uint64)) {
+        memory_inst->mem_bound_check_1byte.u64 = total_size - 1;
+        memory_inst->mem_bound_check_2bytes.u64 = total_size - 2;
+        memory_inst->mem_bound_check_4bytes.u64 = total_size - 4;
+        memory_inst->mem_bound_check_8bytes.u64 = total_size - 8;
+    }
+    else {
+        memory_inst->mem_bound_check_1byte.u32[0] = (uint32)total_size - 1;
+        memory_inst->mem_bound_check_2bytes.u32[0] = (uint32)total_size - 2;
+        memory_inst->mem_bound_check_4bytes.u32[0] = (uint32)total_size - 4;
+        memory_inst->mem_bound_check_8bytes.u32[0] = (uint32)total_size - 8;
+    }
     return true;
 }
-#else
+#else /* else of OS_ENABLE_HW_BOUND_CHECK */
 bool
 aot_enlarge_memory(AOTModuleInstance *module_inst, uint32 inc_page_count)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
-    uint32 num_bytes_per_page =
-        ((AOTModule*)module_inst->aot_module.ptr)->memories[0].num_bytes_per_page;
-    uint32 cur_page_count = memory_inst->mem_cur_page_count;
-    uint32 max_page_count = memory_inst->mem_max_page_count;
+    uint32 num_bytes_per_page = memory_inst->num_bytes_per_page;
+    uint32 cur_page_count = memory_inst->cur_page_count;
+    uint32 max_page_count = memory_inst->max_page_count;
     uint32 total_page_count = cur_page_count + inc_page_count;
-    uint64 memory_data_size = (uint64)num_bytes_per_page * total_page_count;
+    uint64 total_size = (uint64)num_bytes_per_page * total_page_count;
 
     if (inc_page_count <= 0)
         /* No need to enlarge memory */
@@ -1413,8 +1566,9 @@ aot_enlarge_memory(AOTModuleInstance *module_inst, uint32 inc_page_count)
         return false;
     }
 
-    if (os_mprotect(memory_inst->memory_data.ptr, memory_data_size,
-                     MMAP_PROT_READ | MMAP_PROT_WRITE) != 0) {
+    if (os_mprotect(memory_inst->memory_data_end.ptr,
+                    num_bytes_per_page * inc_page_count,
+                    MMAP_PROT_READ | MMAP_PROT_WRITE) != 0) {
         aot_set_exception(module_inst, "fail to enlarge memory.");
         return false;
     }
@@ -1422,18 +1576,26 @@ aot_enlarge_memory(AOTModuleInstance *module_inst, uint32 inc_page_count)
     memset(memory_inst->memory_data_end.ptr, 0,
            num_bytes_per_page * inc_page_count);
 
-    memory_inst->mem_cur_page_count = total_page_count;
-    memory_inst->memory_data_size = (uint32)memory_data_size;
-    memory_inst->memory_data_end.ptr = (uint8*)memory_inst->memory_data.ptr
-                                       + (uint32)memory_data_size;
+    memory_inst->cur_page_count = total_page_count;
+    memory_inst->memory_data_size = (uint32)total_size;
+    memory_inst->memory_data_end.ptr = (uint8 *)memory_inst->memory_data.ptr
+                                       + (uint32)total_size;
 
-    memory_inst->mem_bound_check_1byte = memory_inst->memory_data_size - 1;
-    memory_inst->mem_bound_check_2bytes = memory_inst->memory_data_size - 2;
-    memory_inst->mem_bound_check_4bytes = memory_inst->memory_data_size - 4;
-    memory_inst->mem_bound_check_8bytes = memory_inst->memory_data_size - 8;
+    if (sizeof(uintptr_t) == sizeof(uint64)) {
+        memory_inst->mem_bound_check_1byte.u64 = total_size - 1;
+        memory_inst->mem_bound_check_2bytes.u64 = total_size - 2;
+        memory_inst->mem_bound_check_4bytes.u64 = total_size - 4;
+        memory_inst->mem_bound_check_8bytes.u64 = total_size - 8;
+    }
+    else {
+        memory_inst->mem_bound_check_1byte.u32[0] = (uint32)total_size - 1;
+        memory_inst->mem_bound_check_2bytes.u32[0] = (uint32)total_size - 2;
+        memory_inst->mem_bound_check_4bytes.u32[0] = (uint32)total_size - 4;
+        memory_inst->mem_bound_check_8bytes.u32[0] = (uint32)total_size - 8;
+    }
     return true;
 }
-#endif
+#endif /* end of OS_ENABLE_HW_BOUND_CHECK */
 
 bool
 aot_is_wasm_type_equal(AOTModuleInstance *module_inst,
@@ -1728,21 +1890,17 @@ aot_set_aux_stack(WASMExecEnv *exec_env,
         (AOTModuleInstance*)exec_env->module_inst;
     AOTModule *module = (AOTModule *)module_inst->aot_module.ptr;
 
-    uint32 stack_top_idx =
-        module->llvm_aux_stack_global_index;
-    uint32 data_end =
-        module->llvm_aux_data_end;
-    uint32 stack_bottom =
-        module->llvm_aux_stack_bottom;
-    bool is_stack_before_data =
-        stack_bottom < data_end ? true : false;
+    uint32 stack_top_idx = module->aux_stack_top_global_index;
+    uint32 data_end = module->aux_data_end;
+    uint32 stack_bottom = module->aux_stack_bottom;
+    bool is_stack_before_data = stack_bottom < data_end ? true : false;
 
     /* Check the aux stack space, currently we don't allocate space in heap */
     if ((is_stack_before_data && (size > start_offset))
         || ((!is_stack_before_data) && (start_offset - data_end < size)))
         return false;
 
-    if ((stack_bottom != (uint32)-1) && (stack_top_idx != (uint32)-1)) {
+    if (stack_top_idx != (uint32)-1) {
         /* The aux stack top is a wasm global,
             set the initial value for the global */
         uint32 global_offset =
@@ -1769,8 +1927,8 @@ aot_get_aux_stack(WASMExecEnv *exec_env,
 
     /* The aux stack information is resolved in loader
         and store in module */
-    uint32 stack_bottom = module->llvm_aux_stack_bottom;
-    uint32 total_aux_stack_size = module->llvm_aux_stack_size;
+    uint32 stack_bottom = module->aux_stack_bottom;
+    uint32 total_aux_stack_size = module->aux_stack_size;
 
     if (stack_bottom != 0 && total_aux_stack_size != 0) {
         if (start_offset)

--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -147,6 +147,9 @@ typedef struct AOTModule {
     /* start function, point to AOTed/JITed function */
     void *start_function;
 
+    uint32 malloc_func_index;
+    uint32 free_func_index;
+
     /* AOTed code, NULL for JIT mode */
     void *code;
     uint32 code_size;
@@ -163,10 +166,25 @@ typedef struct AOTModule {
     /* constant string set */
     HashMap *const_str_set;
 
-    uint32 llvm_aux_data_end;
-    uint32 llvm_aux_stack_bottom;
-    uint32 llvm_aux_stack_size;
-    uint32 llvm_aux_stack_global_index;
+    /* the index of auxiliary __data_end global,
+       -1 means unexported */
+    uint32 aux_data_end_global_index;
+    /* auxiliary __data_end exported by wasm app */
+    uint32 aux_data_end;
+
+    /* the index of auxiliary __heap_base global,
+       -1 means unexported */
+    uint32 aux_heap_base_global_index;
+    /* auxiliary __heap_base exported by wasm app */
+    uint32 aux_heap_base;
+
+    /* the index of auxiliary stack top global,
+       -1 means unexported */
+    uint32 aux_stack_top_global_index;
+    /* auxiliary stack bottom resolved */
+    uint32 aux_stack_bottom;
+    /* auxiliary stack size resolved */
+    uint32 aux_stack_size;
 
     /* is jit mode or not */
     bool is_jit_mode;
@@ -188,31 +206,34 @@ typedef union {
     void *ptr;
 } AOTPointer;
 
+typedef union {
+    uint64 u64;
+    uint32 u32[2];
+} MemBound;
+
 typedef struct AOTMemoryInstance {
     uint32 module_type;
     /* shared memory flag */
     bool is_shared;
+
     /* memory space info */
-    uint32 mem_cur_page_count;
-    uint32 mem_max_page_count;
+    uint32 num_bytes_per_page;
+    uint32 cur_page_count;
+    uint32 max_page_count;
     uint32 memory_data_size;
-    uint32 __padding__;
     AOTPointer memory_data;
     AOTPointer memory_data_end;
 
     /* heap space info */
-    int32 heap_base_offset;
-    uint32 heap_data_size;
     AOTPointer heap_data;
     AOTPointer heap_data_end;
     AOTPointer heap_handle;
 
     /* boundary check constants for aot code */
-    int64 mem_bound_check_heap_base;
-    int64 mem_bound_check_1byte;
-    int64 mem_bound_check_2bytes;
-    int64 mem_bound_check_4bytes;
-    int64 mem_bound_check_8bytes;
+    MemBound mem_bound_check_1byte;
+    MemBound mem_bound_check_2bytes;
+    MemBound mem_bound_check_4bytes;
+    MemBound mem_bound_check_8bytes;
 } AOTMemoryInstance;
 
 typedef struct AOTModuleInstance {

--- a/core/iwasm/compilation/aot.c
+++ b/core/iwasm/compilation/aot.c
@@ -375,6 +375,10 @@ aot_create_comp_data(WASMModule *module)
   }
   memset(comp_data->memories, 0, size);
 
+  if (!(module->import_memory_count + module->memory_count)) {
+      comp_data->memories[0].num_bytes_per_page = DEFAULT_NUM_BYTES_PER_PAGE;
+  }
+
   /* Set memory page count */
   for (i = 0; i < module->import_memory_count + module->memory_count; i++) {
     if (i < module->import_memory_count) {
@@ -487,13 +491,19 @@ aot_create_comp_data(WASMModule *module)
       && !(comp_data->funcs = aot_create_funcs(module)))
     goto fail;
 
-  /* Create llvm aux stack informations */
-  comp_data->llvm_aux_stack_global_index = module->llvm_aux_stack_global_index;
-  comp_data->llvm_aux_data_end = module->llvm_aux_data_end;
-  comp_data->llvm_aux_stack_bottom = module->llvm_aux_stack_bottom;
-  comp_data->llvm_aux_stack_size = module->llvm_aux_stack_size;
+  /* Create aux data/heap/stack information */
+  comp_data->aux_data_end_global_index = module->aux_data_end_global_index;
+  comp_data->aux_data_end = module->aux_data_end;
+  comp_data->aux_heap_base_global_index = module->aux_heap_base_global_index;
+  comp_data->aux_heap_base = module->aux_heap_base;
+  comp_data->aux_stack_top_global_index = module->aux_stack_top_global_index;
+  comp_data->aux_stack_bottom = module->aux_stack_bottom;
+  comp_data->aux_stack_size = module->aux_stack_size;
 
   comp_data->start_func_index = module->start_function;
+  comp_data->malloc_func_index = module->malloc_function;
+  comp_data->free_func_index = module->free_function;
+
   comp_data->wasm_module = module;
 
   return comp_data;

--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -201,14 +201,19 @@ typedef struct AOTCompData {
   uint32 func_count;
   AOTFunc **funcs;
 
-  uint32 start_func_index;
-  uint32 addr_data_size;
   uint32 global_data_size;
 
-  uint32 llvm_aux_data_end;
-  uint32 llvm_aux_stack_bottom;
-  uint32 llvm_aux_stack_size;
-  uint32 llvm_aux_stack_global_index;
+  uint32 start_func_index;
+  uint32 malloc_func_index;
+  uint32 free_func_index;
+
+  uint32 aux_data_end_global_index;
+  uint32 aux_data_end;
+  uint32 aux_heap_base_global_index;
+  uint32 aux_heap_base;
+  uint32 aux_stack_top_global_index;
+  uint32 aux_stack_bottom;
+  uint32 aux_stack_size;
 
   WASMModule *wasm_module;
 } AOTCompData;

--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -779,9 +779,10 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
 
       case WASM_OP_MISC_PREFIX:
       {
-        if (frame_ip < frame_ip_end) {
-          opcode = *frame_ip++;
-        }
+        uint32 opcode1;
+
+        read_leb_uint32(frame_ip, frame_ip_end, opcode1);
+        opcode = (uint32)opcode1;
 
         switch (opcode) {
           case WASM_OP_I32_TRUNC_SAT_S_F32:

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -420,9 +420,8 @@ get_init_data_section_size(AOTCompData *comp_data, AOTObjectData *obj_data)
     size = align_uint(size, 4);
     size += (uint32)sizeof(uint32) * 2;
 
-    /* llvm aux data end + llvm aux stack bottom
-       + llvm aux stack size + llvm stack global index */
-    size += sizeof(uint32) * 4;
+    /* aux data/heap/stack data */
+    size += sizeof(uint32) * 7;
 
     size += get_object_data_section_info_size(obj_data);
     return size;
@@ -1190,10 +1189,13 @@ aot_emit_init_data_section(uint8 *buf, uint8 *buf_end, uint32 *p_offset,
     EMIT_U32(comp_data->func_count);
     EMIT_U32(comp_data->start_func_index);
 
-    EMIT_U32(comp_data->llvm_aux_data_end);
-    EMIT_U32(comp_data->llvm_aux_stack_bottom);
-    EMIT_U32(comp_data->llvm_aux_stack_size);
-    EMIT_U32(comp_data->llvm_aux_stack_global_index);
+    EMIT_U32(comp_data->aux_data_end_global_index);
+    EMIT_U32(comp_data->aux_data_end);
+    EMIT_U32(comp_data->aux_heap_base_global_index);
+    EMIT_U32(comp_data->aux_heap_base);
+    EMIT_U32(comp_data->aux_stack_top_global_index);
+    EMIT_U32(comp_data->aux_stack_bottom);
+    EMIT_U32(comp_data->aux_stack_size);
 
     if (!aot_emit_object_data_section_info(buf, buf_end, &offset, obj_data))
         return false;

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -102,7 +102,6 @@ typedef struct AOTCheckedAddr {
 typedef struct AOTMemInfo {
   LLVMValueRef mem_base_addr;
   LLVMValueRef mem_cur_page_count_addr;
-  LLVMValueRef mem_bound_check_heap_base;
   LLVMValueRef mem_bound_check_1byte;
   LLVMValueRef mem_bound_check_2bytes;
   LLVMValueRef mem_bound_check_4bytes;
@@ -190,6 +189,7 @@ typedef struct AOTCompContext {
   LLVMTargetMachineRef target_machine;
   char *target_cpu;
   char target_arch[16];
+  unsigned pointer_size;
 
   /* LLVM execution engine required by JIT */
   LLVMExecutionEngineRef exec_engine;

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -325,15 +325,30 @@ typedef struct WASMModule {
     WASMDataSeg **data_segments;
     uint32 start_function;
 
-    /* __data_end global exported by llvm */
-    uint32 llvm_aux_data_end;
-    /* auxiliary stack bottom, or __heap_base global exported by llvm */
-    uint32 llvm_aux_stack_bottom;
-    /* auxiliary stack size */
-    uint32 llvm_aux_stack_size;
-    /* the index of a global exported by llvm, which is
-       auxiliary stack top pointer */
-    uint32 llvm_aux_stack_global_index;
+    /* the index of auxiliary __data_end global,
+       -1 means unexported */
+    uint32 aux_data_end_global_index;
+    /* auxiliary __data_end exported by wasm app */
+    uint32 aux_data_end;
+
+    /* the index of auxiliary __heap_base global,
+       -1 means unexported */
+    uint32 aux_heap_base_global_index;
+    /* auxiliary __heap_base exported by wasm app */
+    uint32 aux_heap_base;
+
+    /* the index of auxiliary stack top global,
+       -1 means unexported */
+    uint32 aux_stack_top_global_index;
+    /* auxiliary stack bottom resolved */
+    uint32 aux_stack_bottom;
+    /* auxiliary stack size resolved */
+    uint32 aux_stack_size;
+
+    /* the index of malloc/free function,
+       -1 means unexported */
+    uint32 malloc_function;
+    uint32 free_function;
 
     /* Whether there is possible memory grow, e.g. memory.grow opcode */
     bool possible_memory_grow;

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -555,24 +555,27 @@ static bool
 load_table(const uint8 **p_buf, const uint8 *buf_end, WASMTable *table,
            char *error_buf, uint32 error_buf_size)
 {
-    const uint8 *p = *p_buf, *p_end = buf_end;
+    const uint8 *p = *p_buf, *p_end = buf_end, *p_org;
 
     CHECK_BUF(p, p_end, 1);
     /* 0x70 */
     table->elem_type = read_uint8(p);
     bh_assert(TABLE_ELEM_TYPE_ANY_FUNC == table->elem_type);
 
+    p_org = p;
     read_leb_uint32(p, p_end, table->flags);
+    bh_assert(p - p_org <= 1);
+    bh_assert(table->flags <= 1);
+    (void)p_org;
+
     read_leb_uint32(p, p_end, table->init_size);
-    if (table->flags & 1) {
+    if (table->flags == 0) {
+        table->max_size = 0x10000;
+    }
+    else if (table->flags == 1) {
         read_leb_uint32(p, p_end, table->max_size);
         bh_assert(table->init_size <= table->max_size);
     }
-    else
-        table->max_size = 0x10000;
-
-    bh_assert(!((table->flags & 1)
-                && table->init_size > table->max_size));
 
     *p_buf = p;
     return true;
@@ -582,7 +585,7 @@ static bool
 load_memory(const uint8 **p_buf, const uint8 *buf_end, WASMMemory *memory,
             char *error_buf, uint32 error_buf_size)
 {
-    const uint8 *p = *p_buf, *p_end = buf_end;
+    const uint8 *p = *p_buf, *p_end = buf_end, *p_org;
     uint32 pool_size = wasm_runtime_memory_pool_size();
 #if WASM_ENABLE_APP_FRAMEWORK != 0
     uint32 max_page_count = pool_size * APP_MEMORY_MAX_GLOBAL_HEAP_PERCENT
@@ -591,7 +594,15 @@ load_memory(const uint8 **p_buf, const uint8 *buf_end, WASMMemory *memory,
     uint32 max_page_count = pool_size / DEFAULT_NUM_BYTES_PER_PAGE;
 #endif
 
+    p_org = p;
     read_leb_uint32(p, p_end, memory->flags);
+    bh_assert(p - p_org <= 1);
+#if WASM_ENABLE_SHARED_MEMORY == 0
+    bh_assert(memory->flags <= 1);
+#else
+    bh_assert(memory->flags <= 3 && memory->flags != 2);
+#endif
+
     read_leb_uint32(p, p_end, memory->init_page_count);
     bh_assert(memory->init_page_count <= 65536);
 
@@ -602,9 +613,10 @@ load_memory(const uint8 **p_buf, const uint8 *buf_end, WASMMemory *memory,
         if (memory->max_page_count > max_page_count)
             memory->max_page_count = max_page_count;
     }
-    else
+    else {
         /* Limit the maximum memory size to max_page_count */
         memory->max_page_count = max_page_count;
+    }
 
     memory->num_bytes_per_page = DEFAULT_NUM_BYTES_PER_PAGE;
 
@@ -707,7 +719,7 @@ load_import_section(const uint8 *buf, const uint8 *buf_end, WASMModule *module,
 
         p = p_old;
 
-        // TODO: move it out of the loop
+        /* TODO: move it out of the loop */
         /* insert "env", "wasi_unstable" and "wasi_snapshot_preview1" to const str list */
         if (!const_str_list_insert((uint8*)"env", 3, module, error_buf, error_buf_size)
             || !const_str_list_insert((uint8*)"wasi_unstable", 13, module,
@@ -1436,12 +1448,14 @@ load_from_sections(WASMModule *module, WASMSection *sections,
     WASMSection *section = sections;
     const uint8 *buf, *buf_end, *buf_code = NULL, *buf_code_end = NULL,
                 *buf_func = NULL, *buf_func_end = NULL;
-    WASMGlobal *llvm_data_end_global = NULL, *llvm_heap_base_global = NULL;
-    WASMGlobal *llvm_stack_top_global = NULL, *global;
-    uint32 llvm_data_end = UINT32_MAX, llvm_heap_base = UINT32_MAX;
-    uint32 llvm_stack_top = UINT32_MAX, global_index, i;
-    uint32 stack_top_global_index = UINT32_MAX;
+    WASMGlobal *aux_data_end_global = NULL, *aux_heap_base_global = NULL;
+    WASMGlobal *aux_stack_top_global = NULL, *global;
+    uint32 aux_data_end = (uint32)-1, aux_heap_base = (uint32)-1;
+    uint32 aux_stack_top = (uint32)-1, global_index, func_index, i;
+    uint32 aux_data_end_global_index = (uint32)-1;
+    uint32 aux_heap_base_global_index = (uint32)-1;
     BlockAddr *block_addr_cache;
+    WASMType *func_type;
     uint64 total_size;
 
     /* Find code and function sections if have */
@@ -1550,7 +1564,11 @@ load_from_sections(WASMModule *module, WASMSection *sections,
     }
     wasm_runtime_free(block_addr_cache);
 
-    /* Resolve llvm auxiliary data/stack/heap info and reset memory info */
+    module->aux_data_end_global_index = (uint32)-1;
+    module->aux_heap_base_global_index = (uint32)-1;
+    module->aux_stack_top_global_index = (uint32)-1;
+
+    /* Resolve auxiliary data/stack/heap info and reset memory info */
     export = module->exports;
     for (i = 0; i < module->export_count; i++, export++) {
         if (export->kind == EXPORT_KIND_GLOBAL) {
@@ -1561,10 +1579,11 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     && !global->is_mutable
                     && global->init_expr.init_expr_type ==
                             INIT_EXPR_TYPE_I32_CONST) {
-                    llvm_heap_base_global = global;
-                    llvm_heap_base = global->init_expr.u.i32;
-                    LOG_VERBOSE("found llvm __heap_base global, value: %d\n",
-                                llvm_heap_base);
+                    aux_heap_base_global = global;
+                    aux_heap_base = global->init_expr.u.i32;
+                    aux_heap_base_global_index = export->index;
+                    LOG_VERBOSE("Found aux __heap_base global, value: %d",
+                                aux_heap_base);
                 }
             }
             else if (!strcmp(export->name, "__data_end")) {
@@ -1574,89 +1593,155 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     && !global->is_mutable
                     && global->init_expr.init_expr_type ==
                             INIT_EXPR_TYPE_I32_CONST) {
-                    llvm_data_end_global = global;
-                    llvm_data_end = global->init_expr.u.i32;
-                    LOG_VERBOSE("found llvm __data_end global, value: %d\n",
-                                llvm_data_end);
+                    aux_data_end_global = global;
+                    aux_data_end = global->init_expr.u.i32;
+                    aux_data_end_global_index = export->index;
+                    LOG_VERBOSE("Found aux __data_end global, value: %d",
+                                aux_data_end);
 
-                    llvm_data_end = align_uint(llvm_data_end, 16);
+                    aux_data_end = align_uint(aux_data_end, 16);
                 }
             }
 
-            if (llvm_data_end_global && llvm_heap_base_global) {
+            /* For module compiled with -pthread option, the global is:
+                [0] stack_top       <-- 0
+                [1] tls_pointer
+                [2] tls_size
+                [3] data_end        <-- 3
+                [4] global_base
+                [5] heap_base       <-- 5
+                [6] dso_handle
+
+                For module compiled without -pthread option:
+                [0] stack_top       <-- 0
+                [1] data_end        <-- 1
+                [2] global_base
+                [3] heap_base       <-- 3
+                [4] dso_handle
+            */
+            if (aux_data_end_global && aux_heap_base_global
+                && aux_data_end <= aux_heap_base) {
+                module->aux_data_end_global_index = aux_data_end_global_index;
+                module->aux_data_end = aux_data_end;
+                module->aux_heap_base_global_index = aux_heap_base_global_index;
+                module->aux_heap_base = aux_heap_base;
+
                 /* Resolve aux stack top global */
-                for (global_index = 0; global_index < module->global_count; global_index++) {
+                for (global_index = 0; global_index < module->global_count;
+                     global_index++) {
                     global = module->globals + global_index;
-                    if (global != llvm_data_end_global
-                        && global != llvm_heap_base_global
+                    if (global->is_mutable /* heap_base and data_end is
+                                              not mutable */
                         && global->type == VALUE_TYPE_I32
-                        && global->is_mutable
                         && global->init_expr.init_expr_type ==
                                     INIT_EXPR_TYPE_I32_CONST
-                        && (global->init_expr.u.i32 <=
-                                    llvm_heap_base_global->init_expr.u.i32
-                            && llvm_data_end_global->init_expr.u.i32 <=
-                                    llvm_heap_base_global->init_expr.u.i32)) {
-                        llvm_stack_top_global = global;
-                        llvm_stack_top = global->init_expr.u.i32;
-                        stack_top_global_index = global_index;
-                        LOG_VERBOSE("found llvm stack top global, "
-                                    "value: %d, global index: %d\n",
-                                    llvm_stack_top, global_index);
+                        && (uint32)global->init_expr.u.i32 <= aux_heap_base) {
+                        aux_stack_top_global = global;
+                        aux_stack_top = (uint32)global->init_expr.u.i32;
+                        module->aux_stack_top_global_index =
+                                module->import_global_count + global_index;
+                        module->aux_stack_bottom = aux_stack_top;
+                        module->aux_stack_size = aux_stack_top > aux_data_end
+                                                 ? aux_stack_top - aux_data_end
+                                                 : aux_stack_top;
+                        LOG_VERBOSE("Found aux stack top global, value: %d, "
+                                    "global index: %d, stack size: %d",
+                                    aux_stack_top, global_index,
+                                    module->aux_stack_size);
                         break;
                     }
                 }
-
-                module->llvm_aux_data_end = llvm_data_end;
-                module->llvm_aux_stack_bottom = llvm_stack_top;
-                module->llvm_aux_stack_size = llvm_stack_top > llvm_data_end
-                                              ? llvm_stack_top - llvm_data_end
-                                              : llvm_stack_top;
-                module->llvm_aux_stack_global_index = stack_top_global_index;
-                LOG_VERBOSE("aux stack bottom: %d, size: %d\n",
-                            module->llvm_aux_stack_bottom,
-                            module->llvm_aux_stack_size);
                 break;
             }
         }
     }
 
+    module->malloc_function = (uint32)-1;
+    module->free_function = (uint32)-1;
+
+    /* Resolve auxiliary data/stack/heap info and reset memory info */
+    export = module->exports;
+    for (i = 0; i < module->export_count; i++, export++) {
+        if (export->kind == EXPORT_KIND_FUNC) {
+            if (!strcmp(export->name, "malloc")
+                && export->index >= module->import_function_count) {
+                func_index = export->index - module->import_function_count;
+                func_type = module->functions[func_index]->func_type;
+                if (func_type->param_count == 1
+                    && func_type->result_count == 1
+                    && func_type->types[0] == VALUE_TYPE_I32
+                    && func_type->types[1] == VALUE_TYPE_I32) {
+                    module->malloc_function = export->index;
+                    LOG_VERBOSE("Found malloc function, index: %u",
+                                export->index);
+                }
+            }
+            else if (!strcmp(export->name, "free")
+                     && export->index >= module->import_function_count) {
+                func_index = export->index - module->import_function_count;
+                func_type = module->functions[func_index]->func_type;
+                if (func_type->param_count == 1
+                    && func_type->result_count == 0
+                    && func_type->types[0] == VALUE_TYPE_I32) {
+                    module->free_function = export->index;
+                    LOG_VERBOSE("Found free function, index: %u",
+                                export->index);
+                }
+            }
+        }
+    }
+
     if (!module->possible_memory_grow) {
-        if (llvm_data_end_global
-            && llvm_heap_base_global
-            && llvm_stack_top_global
-            && llvm_stack_top <= llvm_heap_base) {
-            WASMMemoryImport *memory_import;
-            WASMMemory *memory;
+        WASMMemoryImport *memory_import;
+        WASMMemory *memory;
+
+        if (aux_data_end_global
+            && aux_heap_base_global
+            && aux_stack_top_global) {
             uint64 init_memory_size;
-            uint32 shrunk_memory_size = llvm_heap_base > llvm_data_end
-                                        ? llvm_heap_base : llvm_data_end;
+            uint32 shrunk_memory_size = align_uint(aux_heap_base, 8);
+
             if (module->import_memory_count) {
                 memory_import = &module->import_memories[0].u.memory;
                 init_memory_size = (uint64)memory_import->num_bytes_per_page *
                                    memory_import->init_page_count;
-                if (llvm_heap_base <= init_memory_size
-                    && llvm_data_end <= init_memory_size) {
+                if (shrunk_memory_size <= init_memory_size) {
                     /* Reset memory info to decrease memory usage */
                     memory_import->num_bytes_per_page = shrunk_memory_size;
                     memory_import->init_page_count = 1;
-                    LOG_VERBOSE("reset import memory size to %d\n",
+                    LOG_VERBOSE("Shrink import memory size to %d",
                                 shrunk_memory_size);
                 }
             }
             if (module->memory_count) {
                 memory = &module->memories[0];
                 init_memory_size = (uint64)memory->num_bytes_per_page *
-                             memory->init_page_count;
-                if (llvm_heap_base <= init_memory_size
-                    && llvm_data_end <= init_memory_size) {
+                                   memory->init_page_count;
+                if (shrunk_memory_size <= init_memory_size) {
                     /* Reset memory info to decrease memory usage */
                     memory->num_bytes_per_page = shrunk_memory_size;
                     memory->init_page_count = 1;
-                    LOG_VERBOSE("reset memory size to %d\n", shrunk_memory_size);
+                    LOG_VERBOSE("Shrink memory size to %d", shrunk_memory_size);
                 }
             }
         }
+
+#if WASM_ENABLE_MULTI_MODULE == 0
+        if (module->import_memory_count) {
+            memory_import = &module->import_memories[0].u.memory;
+            /* Memory init page count cannot be larger than 65536, we don't
+               check integer overflow again. */
+            memory_import->num_bytes_per_page *= memory_import->init_page_count;
+            memory_import->init_page_count = memory_import->max_page_count = 1;
+        }
+        if (module->memory_count) {
+            /* Memory init page count cannot be larger than 65536, we don't
+               check integer overflow again. */
+            memory = &module->memories[0];
+            memory->num_bytes_per_page *= memory->init_page_count;
+            memory->init_page_count = memory->max_page_count = 1;
+        }
+#endif
     }
 
     return true;
@@ -1878,7 +1963,7 @@ wasm_loader_load(const uint8 *buf, uint32 size, char *error_buf, uint32 error_bu
         goto fail;
     }
 
-    LOG_VERBOSE("Load module success");
+    LOG_VERBOSE("Load module success.\n");
     return module;
 
 fail:
@@ -2295,8 +2380,11 @@ wasm_loader_find_block_addr(BlockAddr *block_addr_cache,
                 break;
             case WASM_OP_MISC_PREFIX:
             {
-                opcode = read_uint8(p);
-                switch (opcode) {
+                uint32 opcode1;
+
+                read_leb_uint32(p, p_end, opcode1);
+
+                switch (opcode1) {
                     case WASM_OP_I32_TRUNC_SAT_S_F32:
                     case WASM_OP_I32_TRUNC_SAT_U_F32:
                     case WASM_OP_I32_TRUNC_SAT_S_F64:
@@ -4869,8 +4957,8 @@ handle_op_block_and_loop:
                     || global_type == VALUE_TYPE_F64) {
                     *p_org = WASM_OP_SET_GLOBAL_64;
                 }
-                else if (module->llvm_aux_stack_size > 0
-                         && global_idx == module->llvm_aux_stack_global_index) {
+                else if (module->aux_stack_size > 0
+                         && global_idx == module->aux_stack_top_global_index) {
                     *p_org = WASM_OP_SET_GLOBAL_AUX_STACK;
                 }
 #endif
@@ -4880,8 +4968,8 @@ handle_op_block_and_loop:
                     skip_label();
                     emit_label(WASM_OP_SET_GLOBAL_64);
                 }
-                else if (module->llvm_aux_stack_size > 0
-                         && global_idx == module->llvm_aux_stack_global_index) {
+                else if (module->aux_stack_size > 0
+                         && global_idx == module->aux_stack_top_global_index) {
                     skip_label();
                     emit_label(WASM_OP_SET_GLOBAL_AUX_STACK);
                 }
@@ -5289,12 +5377,13 @@ handle_op_block_and_loop:
 
             case WASM_OP_MISC_PREFIX:
             {
-                opcode = read_uint8(p);
+                uint32 opcode1;
+
+                read_leb_uint32(p, p_end, opcode1);
 #if WASM_ENABLE_FAST_INTERP != 0
-                emit_byte(loader_ctx, opcode);
+                emit_byte(loader_ctx, ((uint8)opcode1));
 #endif
-                switch (opcode)
-                {
+                switch (opcode1) {
                 case WASM_OP_I32_TRUNC_SAT_S_F32:
                 case WASM_OP_I32_TRUNC_SAT_U_F32:
                     POP_AND_PUSH(VALUE_TYPE_F32, VALUE_TYPE_I32);

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -33,18 +33,12 @@ typedef struct WASMMemoryInstance {
     /* Maximum page count */
     uint32 max_page_count;
 
-    /* Heap base offset of wasm app */
-    int32 heap_base_offset;
     /* Heap data base address */
     uint8 *heap_data;
+    /* Heap data end address */
+    uint8 *heap_data_end;
     /* The heap created */
     void *heap_handle;
-
-    /* Memory data */
-    uint8 *memory_data;
-
-    /* End address of memory */
-    uint8 *end_addr;
 
 #if WASM_ENABLE_MULTI_MODULE != 0
     /* to indicate which module instance create it */
@@ -56,13 +50,13 @@ typedef struct WASMMemoryInstance {
     korp_mutex mem_lock;
 #endif
 
-    /* Base address, the layout is:
-       heap_data + memory data
-       memory data init size is: num_bytes_per_page * cur_page_count
+    /* Memory data end address */
+    uint8 *memory_data_end;
+
+    /* Memory data begin address, the layout is: memory data + heap data
        Note: when memory is re-allocated, the heap data and memory data
-             must be copied to new memory also.
-     */
-    uint8 base_addr[1];
+             must be copied to new memory also. */
+    uint8 memory_data[1];
 } WASMMemoryInstance;
 
 typedef struct WASMTableInstance {
@@ -188,6 +182,8 @@ typedef struct WASMModuleInstance {
     uint8 *global_data;
 
     WASMFunctionInstance *start_function;
+    WASMFunctionInstance *malloc_function;
+    WASMFunctionInstance *free_function;
 
     WASMModule *module;
 

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -65,7 +65,7 @@ os_munmap(void *addr, size_t size)
 
     if (addr) {
         if (munmap(addr, request_size)) {
-            os_printf("os_munmap error addr:%p, size:0x%lx, errno:%d\n",
+            os_printf("os_munmap error addr:%p, size:0x%"PRIx64", errno:%d\n",
                       addr, request_size, errno);
         }
     }

--- a/core/shared/platform/darwin/platform_init.c
+++ b/core/shared/platform/darwin/platform_init.c
@@ -16,3 +16,22 @@ bh_platform_destroy()
 {
 }
 
+int
+os_printf(const char *format, ...)
+{
+    int ret = 0;
+    va_list ap;
+
+    va_start(ap, format);
+    ret += vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
+}
+
+int
+os_vprintf(const char *format, va_list ap)
+{
+    return vprintf(format, ap);
+}
+

--- a/core/shared/platform/darwin/platform_internal.h
+++ b/core/shared/platform/darwin/platform_internal.h
@@ -57,9 +57,6 @@ typedef pthread_mutex_t korp_mutex;
 typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
 
-#define os_printf printf
-#define os_vprintf vprintf
-
 #if WASM_DISABLE_HW_BOUND_CHECK == 0
 #if defined(BUILD_TARGET_X86_64) \
     || defined(BUILD_TARGET_AMD_64) \

--- a/core/shared/platform/linux-sgx/sgx_platform.c
+++ b/core/shared/platform/linux-sgx/sgx_platform.c
@@ -152,8 +152,8 @@ int os_mprotect(void *addr, size_t size, int prot)
         mprot |= SGX_PROT_EXEC;
     st = sgx_tprotect_rsrv_mem(addr, aligned_size, mprot);
     if (st != SGX_SUCCESS)
-        os_printf("os_mprotect(addr=0x%lx, size=%u, prot=0x%x) failed.",
-                  addr, size, prot);
+        os_printf("os_mprotect(addr=0x%"PRIx64", size=%u, prot=0x%x) failed.",
+                  (uintptr_t)addr, size, prot);
 
     return (st == SGX_SUCCESS? 0:-1);
 }

--- a/core/shared/platform/linux/platform_init.c
+++ b/core/shared/platform/linux/platform_init.c
@@ -16,3 +16,22 @@ bh_platform_destroy()
 {
 }
 
+int
+os_printf(const char *format, ...)
+{
+    int ret = 0;
+    va_list ap;
+
+    va_start(ap, format);
+    ret += vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
+}
+
+int
+os_vprintf(const char *format, va_list ap)
+{
+    return vprintf(format, ap);
+}
+

--- a/core/shared/platform/linux/platform_internal.h
+++ b/core/shared/platform/linux/platform_internal.h
@@ -56,9 +56,6 @@ typedef pthread_mutex_t korp_mutex;
 typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
 
-#define os_printf printf
-#define os_vprintf vprintf
-
 #if WASM_DISABLE_HW_BOUND_CHECK == 0
 #if defined(BUILD_TARGET_X86_64) \
     || defined(BUILD_TARGET_AMD_64) \

--- a/core/shared/platform/vxworks/platform_init.c
+++ b/core/shared/platform/vxworks/platform_init.c
@@ -16,3 +16,22 @@ bh_platform_destroy()
 {
 }
 
+int
+os_printf(const char *format, ...)
+{
+    int ret = 0;
+    va_list ap;
+
+    va_start(ap, format);
+    ret += vprintf(format, ap);
+    va_end(ap);
+
+    return ret;
+}
+
+int
+os_vprintf(const char *format, va_list ap)
+{
+    return vprintf(format, ap);
+}
+

--- a/core/shared/platform/vxworks/platform_internal.h
+++ b/core/shared/platform/vxworks/platform_internal.h
@@ -55,9 +55,6 @@ typedef pthread_mutex_t korp_mutex;
 typedef pthread_cond_t korp_cond;
 typedef pthread_t korp_thread;
 
-#define os_printf printf
-#define os_vprintf vprintf
-
 #if WASM_DISABLE_HW_BOUND_CHECK == 0
 #if defined(BUILD_TARGET_X86_64) \
     || defined(BUILD_TARGET_AMD_64) \

--- a/core/shared/utils/bh_log.h
+++ b/core/shared/utils/bh_log.h
@@ -54,7 +54,7 @@ bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...);
 #if BH_DEBUG == 1
 #define LOG_DEBUG(...)   bh_log(BH_LOG_LEVEL_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
 #else
-#define LOG_DEBUG(...)   /* do nothing */
+#define LOG_DEBUG(...)   (void)0
 #endif
 
 void

--- a/samples/wasm-c-api/src/callback.c
+++ b/samples/wasm-c-api/src/callback.c
@@ -68,7 +68,11 @@ int main(int argc, const char* argv[]) {
 
   // Load binary.
   printf("Loading binary...\n");
+#if WASM_ENABLE_AOT != 0 && WASM_ENABLE_INTERP == 0
+  FILE* file = fopen("callback.aot", "rb");
+#else
   FILE* file = fopen("callback.wasm", "rb");
+#endif
   if (!file) {
     printf("> Error loading module!\n");
     return 1;


### PR DESCRIPTION
Insert app heap before __heap_base, or before new page
Fix os_printf compilation error in some platforms