### PR TITLE
Add the Windows COFF format support for AOT (#382)

### DIFF
--- a/core/iwasm/aot/arch/aot_reloc_x86_64.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_64.c
@@ -11,6 +11,8 @@
 #define R_X86_64_32     10  /* Direct 32 bit zero extended */
 #define R_X86_64_32S    11  /* Direct 32 bit sign extended */
 
+#define IMAGE_REL_AMD64_REL32 4 /* The 32-bit relative address from the byte following the relocation. */
+
 void __divdi3();
 void __udivdi3();
 void __moddi3();
@@ -174,7 +176,9 @@ apply_relocation(AOTModule *module,
                               "Try using wamrc with --size-level=1 option.");
                 return false;
             }
-
+#ifdef BH_PLATFORM_WINDOWS
+            target_addr -= sizeof(int32);
+#endif
             *(int32*)(target_section_addr + reloc_offset) = (int32)target_addr;
             break;
         }

--- a/core/shared/platform/windows/win_memmap.c
+++ b/core/shared/platform/windows/win_memmap.c
@@ -19,6 +19,9 @@ void * os_mmap(void *hint, size_t size, int prot, int flags)
         /* integer overflow */
         return NULL;
 
+    if (request_size == 0)
+        request_size = page_size;
+
     if (prot & MMAP_PROT_EXEC) {
         if (prot & MMAP_PROT_WRITE)
             flProtect = PAGE_EXECUTE_READWRITE;


### PR DESCRIPTION
Add the Windows COFF format support to wamr-compiler and iwasm can
load and excute it on Windows(X64) platform.

Signed-off-by: Wu Zhongmin <vwzm@live.com>
Signed-off-by: Xiaokang Qin <xiaokang.qxk@antgroup.com>

Co-authored-by: Wu Zhongmin <vwzm@live.com>