### PR TITLE
Use macro instead of enum to define MEM_ALLOCATOR for better compatibility (#399)

### DIFF
--- a/core/config.h
+++ b/core/config.h
@@ -43,12 +43,8 @@
 #define BH_DEBUG 0
 #endif
 
-enum {
-    /* Memory allocator ems */
-    MEM_ALLOCATOR_EMS = 0,
-    /* Memory allocator tlsf */
-    MEM_ALLOCATOR_TLSF
-};
+#define MEM_ALLOCATOR_EMS  0
+#define MEM_ALLOCATOR_TLSF 1
 
 /* Default memory allocator */
 #define DEFAULT_MEM_ALLOCATOR MEM_ALLOCATOR_EMS


### PR DESCRIPTION

Co-authored-by: Huang Qi <huangqi3@xiaomi.com>