### PR TITLE
Add NULL check for memory inst in aot/wasm module malloc/free (#403)

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1280,6 +1280,11 @@ aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
     uint8 *addr = NULL;
     uint32 offset = 0;
 
+    if (!memory_inst) {
+        aot_set_exception(module_inst, "uninitialized memory");
+        return 0;
+    }
+
     if (memory_inst->heap_handle.ptr) {
         addr = mem_allocator_malloc(memory_inst->heap_handle.ptr, size);
     }
@@ -1312,6 +1317,10 @@ aot_module_free(AOTModuleInstance *module_inst, uint32 ptr)
 {
     AOTMemoryInstance *memory_inst = aot_get_default_memory(module_inst);
     AOTModule *module = (AOTModule *)module_inst->aot_module.ptr;
+
+    if (!memory_inst) {
+        return;
+    }
 
     if (ptr) {
         uint8 *addr = (uint8 *)memory_inst->memory_data.ptr + ptr;

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1575,6 +1575,11 @@ wasm_module_malloc(WASMModuleInstance *module_inst, uint32 size,
     uint8 *addr = NULL;
     uint32 offset = 0;
 
+    if (!memory) {
+        wasm_set_exception(module_inst, "uninitialized memory");
+        return 0;
+    }
+
     if (memory->heap_handle) {
         addr = mem_allocator_malloc(memory->heap_handle, size);
     }
@@ -1606,7 +1611,13 @@ wasm_module_free(WASMModuleInstance *module_inst, uint32 ptr)
 {
     if (ptr) {
         WASMMemoryInstance *memory = module_inst->default_memory;
-        uint8 *addr = memory->memory_data + ptr;
+        uint8* addr;
+
+        if (!memory) {
+            return;
+        }
+
+        addr = memory->memory_data + ptr;
 
         if (memory->heap_handle
             && memory->heap_data <= addr


### PR DESCRIPTION
* Add NULL check for memory page in aot/wasm module malloc/free

Signed-off-by: Huang Qi <huangqi3@xiaomi.com>

* Update aot_runtime.c

* Update wasm_runtime.c

Co-authored-by: Huang Qi <huangqi3@xiaomi.com>
Co-authored-by: Wenyong Huang <wenyong.huang@intel.com>