### PR TITLE
Add more checks to enhance security (#446)

### DIFF
--- a/core/iwasm/common/arch/invokeNative_em64_simd.s
+++ b/core/iwasm/common/arch/invokeNative_em64_simd.s
@@ -41,14 +41,14 @@ push_args:
     loop push_args
 push_args_end:
     /* fill all fp args */
-    movdqa 0x00(%rsi), %xmm0
-    movdqa 0x10(%rsi), %xmm1
-    movdqa 0x20(%rsi), %xmm2
-    movdqa 0x30(%rsi), %xmm3
-    movdqa 0x40(%rsi), %xmm4
-    movdqa 0x50(%rsi), %xmm5
-    movdqa 0x60(%rsi), %xmm6
-    movdqa 0x70(%rsi), %xmm7
+    movdqu 0x00(%rsi), %xmm0
+    movdqu 0x10(%rsi), %xmm1
+    movdqu 0x20(%rsi), %xmm2
+    movdqu 0x30(%rsi), %xmm3
+    movdqu 0x40(%rsi), %xmm4
+    movdqu 0x50(%rsi), %xmm5
+    movdqu 0x60(%rsi), %xmm6
+    movdqu 0x70(%rsi), %xmm7
 
     /* fill all int args */
     movq 0x80(%rsi), %rdi

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -2094,6 +2094,11 @@ wasm_application_execute_main(WASMModuleInstanceCommon *module_inst,
         func_type = ((AOTFunctionInstance*)func)->u.func.func_type;
 #endif
 
+    if (!func_type) {
+        LOG_ERROR("invalid module instance type");
+        return false;
+    }
+
     if (!check_main_func_type(func_type)) {
         wasm_runtime_set_exception(module_inst,
                                    "invalid function type of main function");
@@ -2318,7 +2323,7 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
 {
     WASMFunctionInstanceCommon *func;
     WASMType *type = NULL;
-    uint32 argc1, *argv1 = NULL, cell_num, j, k = 0;
+    uint32 argc1, *argv1 = NULL, cell_num = 0, j, k = 0;
     int32 i, p;
     uint64 total_size;
     const char *exception;
@@ -2361,6 +2366,11 @@ wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
                    argc1 : type->ret_cell_num;
     }
 #endif
+
+    if (!type) {
+        LOG_ERROR("invalid module instance type");
+        return false;
+    }
 
     if (type->param_count != (uint32)argc) {
         wasm_runtime_set_exception(module_inst,

--- a/core/iwasm/common/wasm_shared_memory.c
+++ b/core/iwasm/common/wasm_shared_memory.c
@@ -200,8 +200,10 @@ notify_wait_list(bh_list *wait_list, uint32 count)
         notify_count = wait_list->len;
 
     node = bh_list_first_elem(wait_list);
+    if (!node)
+        return 0;
 
-    for (i = 0; i < count; i++) {
+    for (i = 0; i < notify_count; i++) {
         bh_assert(node);
         next = bh_list_elem_next(node);
 

--- a/core/iwasm/compilation/aot_compiler.h
+++ b/core/iwasm/compilation/aot_compiler.h
@@ -180,11 +180,11 @@ typedef enum FloatArithmetic {
       goto fail;                                            \
     }                                                       \
     aot_value = wasm_runtime_malloc(sizeof(AOTValue));      \
-    memset(aot_value, 0, sizeof(AOTValue));                 \
     if (!aot_value) {                                       \
       aot_set_last_error("allocate memory failed.");        \
       goto fail;                                            \
     }                                                       \
+    memset(aot_value, 0, sizeof(AOTValue));                 \
     aot_value->type = value_type;                           \
     aot_value->value = llvm_value;                          \
     aot_value_stack_push                                    \

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -878,7 +878,7 @@ static union {
     uint64 *t = (uint64*)v.i64x2;           \
     CHECK_BUF(16);                          \
     if (!is_little_endian())                \
-        exchange_uint128((uint8 *)&t);      \
+        exchange_uint128((uint8 *)t);       \
     PUT_U64_TO_ADDR(buf + offset, t[0]);    \
     offset += (uint32)sizeof(uint64);       \
     PUT_U64_TO_ADDR(buf + offset, t[1]);    \

--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -155,11 +155,13 @@ handle_next_reachable_block(AOTCompContext *comp_ctx,
 {
     AOTBlock *block = func_ctx->block_stack.block_list_end;
     AOTBlock *block_prev;
-    uint8 *frame_ip;
+    uint8 *frame_ip = NULL;
     uint32 i;
     AOTFuncType *func_type;
 
     aot_checked_addr_list_destroy(func_ctx);
+
+    bh_assert(block);
 
     if (block->label_type == LABEL_TYPE_IF
         && block->llvm_else_block

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2999,7 +2999,7 @@ create_sections(const uint8 *buf, uint32 size,
             section->section_body = (uint8*)p;
             section->section_body_size = section_size;
 
-            if (!*p_section_list)
+            if (!section_list_end)
                 *p_section_list = section_list_end = section;
             else {
                 section_list_end->next = section;

--- a/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
+++ b/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
@@ -265,6 +265,10 @@ call_key_destructor(wasm_exec_env_t exec_env)
     WASMCluster *cluster = wasm_exec_env_get_cluster(exec_env);
     ClusterInfoNode *info = get_cluster_info(cluster);
 
+    if (!info) {
+        return;
+    }
+
     value_node = bh_list_first_elem(info->thread_list);
     while (value_node) {
         if (value_node->exec_env == exec_env)
@@ -435,6 +439,11 @@ get_thread_info(wasm_exec_env_t exec_env, uint32 handle)
 {
     WASMCluster *cluster = wasm_exec_env_get_cluster(exec_env);
     ClusterInfoNode *info = get_cluster_info(cluster);
+
+    if (!info) {
+        return NULL;
+    }
+
     return bh_hash_map_find(info->thread_info_map, (void *)(uintptr_t)handle);
 }
 
@@ -523,6 +532,8 @@ pthread_create_wrapper(wasm_exec_env_t exec_env,
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
     WASIContext *wasi_ctx = get_wasi_ctx(module_inst);
 #endif
+
+    bh_assert(module);
 
     if (!(new_module_inst =
             wasm_runtime_instantiate_internal(module, true, 8192, 0,

--- a/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
+++ b/core/iwasm/libraries/libc-builtin/libc_builtin_wrapper.c
@@ -1007,21 +1007,6 @@ __cxa_throw_wrapper(wasm_exec_env_t exec_env,
     wasm_runtime_set_exception(module_inst, buf);
 }
 
-static int
-setjmp_wrapper(wasm_exec_env_t exec_env,
-               void *jmp_buf)
-{
-    os_printf("in setjmp()\n");
-    return 0;
-}
-
-static void
-longjmp_wrapper(wasm_exec_env_t exec_env,
-               void *jmp_buf, int val)
-{
-    os_printf("in longjmp()\n");
-}
-
 #if WASM_ENABLE_SPEC_TEST != 0
 static void
 print_wrapper(wasm_exec_env_t exec_env)
@@ -1120,8 +1105,6 @@ static NativeSymbol native_symbols_libc_builtin[] = {
     REG_NATIVE_FUNC(__cxa_allocate_exception, "(i)i"),
     REG_NATIVE_FUNC(__cxa_begin_catch, "(*)"),
     REG_NATIVE_FUNC(__cxa_throw, "(**i)"),
-    REG_NATIVE_FUNC(setjmp, "(*)i"),
-    REG_NATIVE_FUNC(longjmp, "(*i)"),
 };
 
 #if WASM_ENABLE_SPEC_TEST != 0

--- a/core/iwasm/libraries/libc-emcc/libc_emcc_wrapper.c
+++ b/core/iwasm/libraries/libc-emcc/libc_emcc_wrapper.c
@@ -267,6 +267,21 @@ getentropy_wrapper(wasm_exec_env_t exec_env, void *buffer, uint32 length)
     return getentropy(buffer, length);
 }
 
+static int
+setjmp_wrapper(wasm_exec_env_t exec_env,
+               void *jmp_buf)
+{
+    os_printf("setjmp() called\n");
+    return 0;
+}
+
+static void
+longjmp_wrapper(wasm_exec_env_t exec_env,
+               void *jmp_buf, int val)
+{
+    os_printf("longjmp() called\n");
+}
+
 #if !defined(BH_PLATFORM_LINUX_SGX)
 static FILE *file_list[32] = { 0 };
 
@@ -506,6 +521,8 @@ static NativeSymbol native_symbols_libc_emcc[] = {
     REG_NATIVE_FUNC(munmap, "(ii)i"),
     REG_NATIVE_FUNC(__munmap, "(ii)i"),
     REG_NATIVE_FUNC(getentropy, "(*~)i"),
+    REG_NATIVE_FUNC(setjmp, "(*)i"),
+    REG_NATIVE_FUNC(longjmp, "(*i)"),
 #if !defined(BH_PLATFORM_LINUX_SGX)
     REG_NATIVE_FUNC(fopen, "($$)i"),
     REG_NATIVE_FUNC(fread, "(*iii)i"),

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -1019,9 +1019,13 @@ wasi_poll_oneoff(wasm_exec_env_t exec_env,
     return 0;
 }
 
-void wasi_proc_exit(wasm_exec_env_t exec_env, wasi_exitcode_t rval)
+static void
+wasi_proc_exit(wasm_exec_env_t exec_env, wasi_exitcode_t rval)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
+    /* Here throwing exception is just to let wasm app exit,
+       the upper layer should clear the exception and return
+       as normal */
     wasm_runtime_set_exception(module_inst, "wasi proc exit");
 }
 

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -1902,9 +1902,9 @@ __wasi_errno_t wasmtime_ssp_path_open(
     }
 
     if (S_ISDIR(sb.st_mode))
-      rights_base |= RIGHTS_DIRECTORY_BASE;
+      rights_base |= (__wasi_rights_t)RIGHTS_DIRECTORY_BASE;
     else if (S_ISREG(sb.st_mode))
-      rights_base |= RIGHTS_REGULAR_FILE_BASE;
+      rights_base |= (__wasi_rights_t)RIGHTS_REGULAR_FILE_BASE;
   }
 
   return fd_table_insert_fd(curfds, nfd, type, rights_base & max_base,

--- a/core/iwasm/libraries/thread-mgr/thread_manager.c
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.c
@@ -288,6 +288,10 @@ wasm_cluster_spawn_exec_env(WASMExecEnv *exec_env)
     WASMExecEnv *new_exec_env;
     uint32 aux_stack_start, aux_stack_size;
 
+    if (!module) {
+        return NULL;
+    }
+
     if (!(new_module_inst =
         wasm_runtime_instantiate_internal(module, true, 8192,
                                           0, NULL, 0))) {

--- a/core/shared/platform/zephyr/zephyr_platform.c
+++ b/core/shared/platform/zephyr/zephyr_platform.c
@@ -87,6 +87,7 @@ os_free(void *ptr)
 {
 }
 
+#if 0
 struct out_context {
     int count;
 };
@@ -100,13 +101,19 @@ char_out(int c, void *ctx)
     out_ctx->count++;
     return _stdout_hook_iwasm(c);
 }
+#endif
 
 int
 os_vprintf(const char *fmt, va_list ap)
 {
+#if 0
     struct out_context ctx = { 0 };
     z_vprintk(char_out, &ctx, fmt, ap);
     return ctx.count;
+#else
+    vprintk(fmt, ap);
+    return 0;
+#endif
 }
 
 void *

--- a/core/shared/utils/bh_assert.c
+++ b/core/shared/utils/bh_assert.c
@@ -8,8 +8,6 @@
 void bh_assert_internal(int v, const char *file_name, int line_number,
                         const char *expr_string)
 {
-    int i;
-
     if (v)
         return;
 
@@ -22,10 +20,6 @@ void bh_assert_internal(int v, const char *file_name, int line_number,
     os_printf("\nASSERTION FAILED: %s, at file %s, line %d\n",
               expr_string, file_name, line_number);
 
-    i = os_printf(" ");
-
-    /* divived by 0 to make it abort */
-    os_printf("%d\n", i / (i - 1));
-    while (1);
+    abort();
 }
 

--- a/core/shared/utils/bh_hashmap.c
+++ b/core/shared/utils/bh_hashmap.c
@@ -290,11 +290,11 @@ bh_hash_map_destroy(HashMap *map)
 uint32
 bh_hash_map_get_struct_size(HashMap *hashmap)
 {
-    uint32 size = offsetof(HashMap, elements)
-                  + sizeof(HashMapElem *) * hashmap->size;
+    uint32 size = (uint32)(uintptr_t)offsetof(HashMap, elements)
+                  + (uint32)sizeof(HashMapElem *) * hashmap->size;
 
     if (hashmap->lock) {
-        size += sizeof(korp_mutex);
+        size += (uint32)sizeof(korp_mutex);
     }
 
     return size;
@@ -303,7 +303,7 @@ bh_hash_map_get_struct_size(HashMap *hashmap)
 uint32
 bh_hash_map_get_elem_struct_size()
 {
-    return sizeof(HashMapElem);
+    return (uint32)sizeof(HashMapElem);
 }
 
 bool

--- a/samples/gui/wasm-runtime-wgl/src/platform/linux/iwasm_main.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/linux/iwasm_main.c
@@ -443,7 +443,10 @@ static void hal_init(void)
 
     /*Create a display*/
     lv_disp_drv_t disp_drv;
-    lv_disp_drv_init(&disp_drv);            /*Basic initialization*/
+
+    /*Basic initialization*/
+    memset(&disp_drv, 0, sizeof(disp_drv));
+    lv_disp_drv_init(&disp_drv);
     disp_drv.buffer = &disp_buf1;
     disp_drv.flush_cb = monitor_flush;
     //    disp_drv.hor_res = 200;

--- a/samples/workload/wasm-av1/README.md
+++ b/samples/workload/wasm-av1/README.md
@@ -39,7 +39,7 @@ Firstly please build iwasm with simd support:
 ``` shell
 $ cd <wamr dir>/product-mini/platforms/linux/
 $ mkdir build && cd build
-$ cmake .. -DWAMR_BUILD_SIMD=1
+$ cmake .. -DWAMR_BUILD_SIMD=1 -DWAMR_BUILD_LIBC_EMCC=1
 $ make
 ```
 

--- a/samples/workload/wasm-av1/wasm-av1.patch
+++ b/samples/workload/wasm-av1/wasm-av1.patch
@@ -30,7 +30,7 @@ index c39fff6..4682d43 100644
  		)
  
 diff --git a/test.c b/test.c
-index df2d44b..8e81cdc 100644
+index df2d44b..cb270de 100644
 --- a/test.c
 +++ b/test.c
 @@ -18,6 +18,9 @@
@@ -58,7 +58,7 @@ index df2d44b..8e81cdc 100644
      fclose(f);
  }
  
-@@ -63,6 +67,7 @@ main(int argc, char *argv[]) {
+@@ -63,9 +67,12 @@ main(int argc, char *argv[]) {
                      static int     i = 0;
                      
                      ++i;
@@ -66,6 +66,11 @@ index df2d44b..8e81cdc 100644
                      if (30 <= i && i < 40) {
                          dump_raw_frame(af, i);
                      }
++                    if (i >= 1000)
++                        break;
+                 }
+                 /*
+                  * Run the decoder every time, so that we keep
 diff --git a/third_party/aom/CMakeLists.txt b/third_party/aom/CMakeLists.txt
 index 9dbe301..20c7be4 100644
 --- a/third_party/aom/CMakeLists.txt

--- a/wamr-compiler/main.c
+++ b/wamr-compiler/main.c
@@ -159,7 +159,7 @@ main(int argc, char *argv[])
       return print_help();
   }
 
-  if (argc == 0)
+  if (argc == 0 || !out_file_name)
     return print_help();
 
   if (sgx_mode) {


### PR DESCRIPTION
add more checks to enhance security
clear "wasi proc exit" exception before return to caller in wasm/aot call functions
fix memory profiling issue
change movdqa to movdqu in simd invokeNative asm codes to fix issue of unaligned address access
move setjmp/longjmp from libc-builtin to libc-emcc
fix zephyr platform compilation issue in latest zephyr version