### PR TITLE
Addapt to RIOT changes (#452)

### DIFF
--- a/core/shared/platform/riot/platform_internal.h
+++ b/core/shared/platform/riot/platform_internal.h
@@ -8,7 +8,7 @@
 #define _PLATFORM_INTERNAL_H
 
 //Riot includes core
-#include <kernel_types.h>
+#include <sched.h>
 #include <thread.h>
 #include <mutex.h>
 


### PR DESCRIPTION
RIOT removed kernel_types.h in favor of sched.h