### PR TITLE
Modify os_cond_reltimedwait to support long time wait (#461)

### DIFF
--- a/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
+++ b/core/iwasm/libraries/lib-pthread/lib_pthread_wrapper.c
@@ -848,7 +848,7 @@ pthread_cond_wait_wrapper(wasm_exec_env_t exec_env, uint32 *cond, uint32 *mutex)
 */
 static int32
 pthread_cond_timedwait_wrapper(wasm_exec_env_t exec_env, uint32 *cond,
-                               uint32 *mutex, uint32 useconds)
+                               uint32 *mutex, uint64 useconds)
 {
     ThreadInfoNode *cond_info_node, *mutex_info_node;
 
@@ -1014,7 +1014,7 @@ static NativeSymbol native_symbols_lib_pthread[] = {
     REG_NATIVE_FUNC(pthread_mutex_destroy,  "(*)i"),
     REG_NATIVE_FUNC(pthread_cond_init,      "(**)i"),
     REG_NATIVE_FUNC(pthread_cond_wait,      "(**)i"),
-    REG_NATIVE_FUNC(pthread_cond_timedwait, "(**i)i"),
+    REG_NATIVE_FUNC(pthread_cond_timedwait, "(**I)i"),
     REG_NATIVE_FUNC(pthread_cond_signal,    "(*)i"),
     REG_NATIVE_FUNC(pthread_cond_destroy,   "(*)i"),
     REG_NATIVE_FUNC(pthread_key_create,     "(*i)i"),

--- a/core/shared/platform/alios/alios_thread.c
+++ b/core/shared/platform/alios/alios_thread.c
@@ -273,7 +273,7 @@ os_cond_destroy(korp_cond *cond)
 
 static int
 os_cond_wait_internal(korp_cond *cond, korp_mutex *mutex,
-                      bool timed, int mills)
+                      bool timed, uint32 mills)
 {
     os_thread_wait_node *node = &thread_data_current()->wait_node;
 
@@ -319,12 +319,25 @@ os_cond_wait(korp_cond *cond, korp_mutex *mutex)
 }
 
 int
-os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, int useconds)
+os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, uint64 useconds)
 {
-    if (useconds == BHT_WAIT_FOREVER)
+    if (useconds == BHT_WAIT_FOREVER) {
         return os_cond_wait_internal(cond, mutex, false, 0);
-    else
-        return os_cond_wait_internal(cond, mutex, true, useconds / 1000);
+    }
+    else {
+        uint64 mills_64 = useconds / 1000;
+        uint32 mills;
+
+        if (mills_64 < (uint64)(UINT32_MAX - 1)) {
+            mills = (uint64)mills_64;
+        }
+        else {
+            mills = UINT32_MAX - 1;
+            os_printf("Warning: os_cond_reltimedwait exceeds limit, "
+                      "set to max timeout instead\n");
+        }
+        return os_cond_wait_internal(cond, mutex, true, mills);
+    }
 }
 
 int

--- a/core/shared/platform/common/freertos/freertos_thread.c
+++ b/core/shared/platform/common/freertos/freertos_thread.c
@@ -404,12 +404,25 @@ int os_cond_wait(korp_cond *cond, korp_mutex *mutex)
     return os_cond_wait_internal(cond, mutex, false, 0);
 }
 
-int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, int useconds)
+int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, uint64 useconds)
 {
-    if (useconds == BHT_WAIT_FOREVER)
+    if (useconds == BHT_WAIT_FOREVER) {
         return os_cond_wait_internal(cond, mutex, false, 0);
-    else
-        return os_cond_wait_internal(cond, mutex, true, useconds / 1000);
+    }
+    else {
+        uint64 mills_64 = useconds / 1000;
+        int32 mills;
+
+        if (mills_64 < (uint64)INT32_MAX) {
+            mills = (int32)mills_64;
+        }
+        else {
+            mills = INT32_MAX;
+            os_printf("Warning: os_cond_reltimedwait exceeds limit, "
+                      "set to max timeout instead\n");
+        }
+        return os_cond_wait_internal(cond, mutex, true, mills);
+    }
 }
 
 int os_cond_signal(korp_cond *cond)

--- a/core/shared/platform/include/platform_api_extension.h
+++ b/core/shared/platform/include/platform_api_extension.h
@@ -138,7 +138,7 @@ int os_cond_wait(korp_cond *cond, korp_mutex *mutex);
  *
  * @return 0 if success
  */
-int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, int useconds);
+int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, uint64 useconds);
 
 /**
  * Signals the condition variable

--- a/core/shared/platform/include/platform_common.h
+++ b/core/shared/platform/include/platform_common.h
@@ -19,8 +19,7 @@ extern "C" {
 #define BHT_TIMED_OUT (1)
 #define BHT_OK (0)
 
-#define BHT_NO_WAIT 0x00000000
-#define BHT_WAIT_FOREVER 0xFFFFFFFF
+#define BHT_WAIT_FOREVER ((uint64)-1LL)
 
 #define BH_KB (1024)
 #define BH_MB ((BH_KB)*1024)

--- a/core/shared/platform/linux-sgx/sgx_thread.c
+++ b/core/shared/platform/linux-sgx/sgx_thread.c
@@ -129,7 +129,7 @@ int os_cond_wait(korp_cond *cond, korp_mutex *mutex)
     return BHT_OK;
 }
 
-int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, int useconds)
+int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, uint64 useconds)
 {
     os_printf("warning: SGX pthread_cond_timedwait isn't supported, "
               "calling pthread_cond_wait instead!\n");

--- a/core/shared/platform/riot/riot_thread.c
+++ b/core/shared/platform/riot/riot_thread.c
@@ -399,11 +399,10 @@ os_cond_wait(korp_cond *cond, korp_mutex *mutex)
 }
 
 int
-os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, int useconds)
+os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, uint64 useconds)
 {
-    uint64 useconds64 = (uint64) useconds;
     return os_cond_wait_internal(cond, mutex,
-                                 (useconds64 != BHT_WAIT_FOREVER), useconds64);
+                                 (useconds != BHT_WAIT_FOREVER), useconds);
 }
 
 int

--- a/core/shared/platform/windows/win_thread.c
+++ b/core/shared/platform/windows/win_thread.c
@@ -125,7 +125,7 @@ static void msec_nsec_to_abstime(struct timespec *ts, int usec)
     }
 }
 
-int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, int useconds)
+int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, uint64 useconds)
 {
     return BHT_OK;
 }

--- a/core/shared/platform/zephyr/zephyr_thread.c
+++ b/core/shared/platform/zephyr/zephyr_thread.c
@@ -420,13 +420,26 @@ int os_cond_wait(korp_cond *cond, korp_mutex *mutex)
     return os_cond_wait_internal(cond, mutex, false, 0);
 }
 
-int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, int useconds)
+int os_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, uint64 useconds)
 {
 
-    if (useconds == BHT_WAIT_FOREVER)
+    if (useconds == BHT_WAIT_FOREVER) {
         return os_cond_wait_internal(cond, mutex, false, 0);
-    else
-        return os_cond_wait_internal(cond, mutex, true, useconds / 1000);
+    }
+    else {
+        uint64 mills_64 = useconds / 1000;
+        int32 mills;
+
+        if (mills_64 < (uint64)INT32_MAX) {
+            mills = (int32)mills_64;
+        }
+        else {
+            mills = INT32_MAX;
+            os_printf("Warning: os_cond_reltimedwait exceeds limit, "
+                      "set to max timeout instead\n");
+        }
+        return os_cond_wait_internal(cond, mutex, true, mills);
+    }
 }
 
 int os_cond_signal(korp_cond *cond)

--- a/core/shared/utils/bh_queue.c
+++ b/core/shared/utils/bh_queue.c
@@ -171,7 +171,7 @@ void bh_free_msg(bh_queue_node *msg)
     bh_queue_free(msg);
 }
 
-bh_message_t bh_get_msg(bh_queue *queue, int timeout)
+bh_message_t bh_get_msg(bh_queue *queue, uint64 timeout_us)
 {
     bh_queue_node *msg = NULL;
     bh_queue_mutex_lock(&queue->queue_lock);
@@ -180,13 +180,13 @@ bh_message_t bh_get_msg(bh_queue *queue, int timeout)
         bh_assert(queue->head == NULL);
         bh_assert(queue->tail == NULL);
 
-        if (timeout == 0) {
+        if (timeout_us == 0) {
             bh_queue_mutex_unlock(&queue->queue_lock);
             return NULL;
         }
 
         bh_queue_cond_timedwait(&queue->queue_wait_cond, &queue->queue_lock,
-                                timeout);
+                                timeout_us);
     }
 
     if (queue->cnt == 0) {
@@ -226,7 +226,7 @@ void bh_queue_enter_loop_run(bh_queue *queue,
         return;
 
     while (!queue->exit_loop_run) {
-        bh_queue_node * message = bh_get_msg(queue, (int)BHT_WAIT_FOREVER);
+        bh_queue_node * message = bh_get_msg(queue, BHT_WAIT_FOREVER);
 
         if (message) {
             handle_cb(message, arg);

--- a/core/shared/utils/bh_queue.h
+++ b/core/shared/utils/bh_queue.h
@@ -56,7 +56,7 @@ bool bh_post_msg(bh_queue *queue, unsigned short tag, void *body,
                  unsigned int len);
 bool bh_post_msg2(bh_queue *queue, bh_message_t msg);
 
-bh_message_t bh_get_msg(bh_queue *queue, int timeout);
+bh_message_t bh_get_msg(bh_queue *queue, uint64 timeout_us);
 
 unsigned
 bh_queue_get_message_count(bh_queue *queue);

--- a/core/shared/utils/runtime_timer.h
+++ b/core/shared/utils/runtime_timer.h
@@ -32,7 +32,7 @@ bool sys_timer_destroy(timer_ctx_t ctx, uint32 timer_id);
 bool sys_timer_cancel(timer_ctx_t ctx, uint32 timer_id);
 bool sys_timer_restart(timer_ctx_t ctx, uint32 timer_id, int interval);
 void cleanup_app_timers(timer_ctx_t ctx);
-int check_app_timers(timer_ctx_t ctx);
+uint32 check_app_timers(timer_ctx_t ctx);
 uint32 get_expiry_ms(timer_ctx_t ctx);
 
 #ifdef __cplusplus

--- a/wamr-sdk/app/libc-builtin-sysroot/include/pthread.h
+++ b/wamr-sdk/app/libc-builtin-sysroot/include/pthread.h
@@ -6,6 +6,8 @@
 #ifndef _WAMR_LIB_PTHREAD_H
 #define _WAMR_LIB_PTHREAD_H
 
+#include <stdint.h>
+
 /* Data type define of pthread, mutex, cond and key */
 typedef unsigned int pthread_t;
 typedef unsigned int pthread_mutex_t;
@@ -41,7 +43,7 @@ int pthread_cond_init(pthread_cond_t *cond, const void *attr);
 int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
 
 int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex,
-                           unsigned int useconds);
+                           uint64_t useconds);
 
 int pthread_cond_signal(pthread_cond_t *cond);
 


### PR DESCRIPTION
Modify the argument of os_cond_reltimedwait to uint64 type to support long time wait, and handle possible integer overflow.