### PR TITLE
Fix wamr compiler issues and refine some error messages (#470)

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -894,15 +894,12 @@ load_import_funcs(const uint8 **p_buf, const uint8 *buf_end,
 
         module_name = import_funcs[i].module_name;
         field_name = import_funcs[i].func_name;
-        if (!(import_funcs[i].func_ptr_linked =
+        import_funcs[i].func_ptr_linked =
                     wasm_native_resolve_symbol(module_name, field_name,
                                                import_funcs[i].func_type,
                                                &import_funcs[i].signature,
                                                &import_funcs[i].attachment,
-                                               &import_funcs[i].call_conv_raw))) {
-            LOG_WARNING("warning: fail to link import function (%s, %s)\n",
-                        module_name, field_name);
-        }
+                                               &import_funcs[i].call_conv_raw);
 
 #if WASM_ENABLE_LIBC_WASI != 0
         if (!strcmp(import_funcs[i].module_name, "wasi_unstable")

--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -1036,8 +1036,8 @@ build_atomic_rmw:
       case WASM_OP_SIMD_PREFIX:
       {
         if (!comp_ctx->enable_simd) {
-            aot_set_last_error(
-              "current building does not support SIMD instructions");
+            aot_set_last_error("SIMD instruction was found, "
+                               "try adding --enable-simd option?");
             return false;
         }
 

--- a/core/iwasm/compilation/aot_llvm_extra.cpp
+++ b/core/iwasm/compilation/aot_llvm_extra.cpp
@@ -115,9 +115,10 @@ aot_check_simd_compatibility(const char *arch_c_str, const char *cpu_c_str)
 
     llvm::SmallVector<std::string, 1> targetAttributes;
     llvm::Triple targetTriple(arch_c_str, "", "");
-    llvm::TargetMachine *targetMachine = llvm::EngineBuilder().selectTarget(
-      targetTriple, "", std::string(cpu_c_str), targetAttributes);
-    if (targetMachine == nullptr) {
+    auto targetMachine =
+      std::unique_ptr<llvm::TargetMachine>(llvm::EngineBuilder().selectTarget(
+        targetTriple, "", std::string(cpu_c_str), targetAttributes));
+    if (!targetMachine) {
         return false;
     }
 

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -941,7 +941,7 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
 
     if (!func_import->func_ptr_linked) {
         snprintf(buf, sizeof(buf),
-                 "fail to call unlinked import function (%s, %s)",
+                 "failed to call unlinked import function (%s, %s)",
                  func_import->module_name, func_import->field_name);
         wasm_set_exception(module_inst, buf);
         return;
@@ -998,7 +998,7 @@ wasm_interp_call_func_import(WASMModuleInstance *module_inst,
 
     if (!sub_func_inst) {
         snprintf(buf, sizeof(buf),
-                 "fail to call unlinked import function (%s, %s)",
+                 "failed to call unlinked import function (%s, %s)",
                  func_import->module_name, func_import->field_name);
         wasm_set_exception(module_inst, buf);
         return;
@@ -1865,7 +1865,7 @@ label_pop_csp_n:
         delta = (uint32)POP_I32();
 
         if (!wasm_enlarge_memory(module, delta)) {
-          /* fail to memory.grow, return -1 */
+          /* failed to memory.grow, return -1 */
           PUSH_I32(-1);
         }
         else {

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -987,8 +987,8 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
 
     if (!func_import->func_ptr_linked) {
         char buf[128];
-        snprintf(buf,
-                 sizeof(buf), "fail to call unlinked import function (%s, %s)",
+        snprintf(buf, sizeof(buf),
+                 "failed to call unlinked import function (%s, %s)",
                  func_import->module_name, func_import->field_name);
         wasm_set_exception((WASMModuleInstance*)module_inst, buf);
         return;
@@ -1043,7 +1043,7 @@ wasm_interp_call_func_import(WASMModuleInstance *module_inst,
 
     if (!sub_func_inst) {
         snprintf(buf, sizeof(buf),
-                 "fail to call unlinked import function (%s, %s)",
+                 "failed to call unlinked import function (%s, %s)",
                  func_import->module_name, func_import->field_name);
         wasm_set_exception(module_inst, buf);
         return;
@@ -1796,7 +1796,7 @@ recover_br_info:
         delta = (uint32)frame_lp[addr1];
 
         if (!wasm_enlarge_memory(module, delta)) {
-          /* fail to memory.grow, return -1 */
+          /* failed to memory.grow, return -1 */
           frame_lp[addr_ret] = -1;
         }
         else {

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -1841,8 +1841,12 @@ load_function_section(const uint8 *buf, const uint8 *buf_end,
 #endif
 #endif
                         ) {
-                    set_error_buf(error_buf, error_buf_size,
-                                  "invalid local type");
+                    if (type == VALUE_TYPE_V128)
+                        set_error_buf(error_buf, error_buf_size,
+                                      "v128 value type requires simd feature");
+                    else
+                        set_error_buf_v(error_buf, error_buf_size,
+                                        "invalid local type 0x%02X", type);
                     return false;
                 }
                 for (k = 0; k < sub_local_count; k++) {

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -388,19 +388,6 @@ load_function_import(const WASMModule *parent_module, WASMModule *sub_module,
                                                  &linked_call_conv_raw);
     }
 
-    if (!linked_func) {
-#if WASM_ENABLE_SPEC_TEST != 0
-        set_error_buf(error_buf, error_buf_size,
-                      "unknown import or incompatible import type");
-        return false;
-#else
-#if WASM_ENABLE_WAMR_COMPILER == 0
-        LOG_WARNING("warning: fail to link import function (%s, %s)",
-                    sub_module_name, function_name);
-#endif
-#endif
-    }
-
     function->module_name = sub_module_name;
     function->field_name = function_name;
     function->func_type = declare_func_type;

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1097,7 +1097,7 @@ check_linked_symbol(WASMModuleInstance *module_inst, char *error_buf,
             return false;
 #else
 #if WASM_ENABLE_WAMR_COMPILER == 0
-            LOG_WARNING("warning: fail to link import function (%s, %s)",
+            LOG_WARNING("warning: failed to link import function (%s, %s)",
                         func->module_name, func->field_name);
 #else
             /* do nothing to avoid confused message */
@@ -1115,7 +1115,7 @@ check_linked_symbol(WASMModuleInstance *module_inst, char *error_buf,
             return false;
 #else
 #if WASM_ENABLE_WAMR_COMPILER == 0
-            LOG_DEBUG("warning: fail to link import global (%s, %s)",
+            LOG_DEBUG("warning: failed to link import global (%s, %s)",
                       global->module_name, global->field_name);
 #else
             /* do nothing to avoid confused message */

--- a/samples/littlevgl/wasm-apps/src/main.c
+++ b/samples/littlevgl/wasm-apps/src/main.c
@@ -159,6 +159,13 @@ static void hal_init(void)
     indev_drv.type = LV_INDEV_TYPE_POINTER;
     indev_drv.read = display_input_read; /*This function will be called periodically (by the library) to get the mouse position and state*/
     lv_indev_t * mouse_indev = lv_indev_drv_register(&indev_drv);
+}
 
+/* Implement empry main function as wasi start function calls it */
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    return 0;
 }
 


### PR DESCRIPTION
Fix potential memory leak issue when using llvm::EngineBuilder().selectTarget()
Fix issue of accessing aot_value's fields after it is freed
Fix JIT not print failed to link import warning
Change some error messages: 'fail to' to 'failed to'
Update error message when SIMD isn't enabled
Fix install littlevgl wasm app of wasi version failed

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>