### PR TITLE
Update wasm app build scripts for wasi-sdk-12 and refine interpreter (#481)

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -2039,12 +2039,9 @@ wasm_application_execute_main(WASMModuleInstanceCommon *module_inst,
     }
 #endif /* end of WASM_ENABLE_LIBC_WASI */
 
-    func = resolve_function(module_inst, "_main");
-    if (!func) {
-        func = resolve_function(module_inst, "main");
-    }
-
-    if (!func) {
+    if (!(func = resolve_function(module_inst, "main"))
+        && !(func = resolve_function(module_inst, "__main_argc_argv"))
+        && !(func = resolve_function(module_inst, "_main"))) {
         wasm_runtime_set_exception(module_inst,
                                    "lookup main function failed");
         return false;

--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -383,7 +383,7 @@ aot_compile_op_block(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     /* Get block info */
     if (!(wasm_loader_find_block_addr((BlockAddr*)block_addr_cache,
                                       *p_frame_ip, frame_ip_end, (uint8)label_type,
-                                      &else_addr, &end_addr, NULL, 0))) {
+                                      &else_addr, &end_addr))) {
         aot_set_last_error("find block end addr failed.");
         return false;
     }

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -405,10 +405,10 @@ typedef struct BlockType {
 } BlockType;
 
 typedef struct WASMBranchBlock {
-    uint8 label_type;
-    uint32 cell_num;
+    uint8 *begin_addr;
     uint8 *target_addr;
     uint32 *frame_sp;
+    uint32 cell_num;
 } WASMBranchBlock;
 
 /* Execution environment, e.g. stack info */

--- a/core/iwasm/interpreter/wasm_loader.h
+++ b/core/iwasm/interpreter/wasm_loader.h
@@ -68,9 +68,7 @@ wasm_loader_find_block_addr(BlockAddr *block_addr_cache,
                             const uint8 *code_end_addr,
                             uint8 block_type,
                             uint8 **p_else_addr,
-                            uint8 **p_end_addr,
-                            char *error_buf,
-                            uint32 error_buf_size);
+                            uint8 **p_end_addr);
 
 #ifdef __cplusplus
 }

--- a/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
+++ b/core/iwasm/libraries/libc-wasi/libc_wasi_wrapper.c
@@ -340,7 +340,6 @@ wasi_fd_pread(wasm_exec_env_t exec_env,
     wasi_iovec_t *iovec, *iovec_begin;
     uint64 total_size;
     size_t nread;
-    uint32 mem;
     uint32 i;
     wasi_errno_t err;
 
@@ -355,7 +354,7 @@ wasi_fd_pread(wasm_exec_env_t exec_env,
 
     total_size = sizeof(wasi_iovec_t) * (uint64)iovs_len;
     if (total_size >= UINT32_MAX
-        || !(mem = module_malloc((uint32)total_size, (void**)&iovec_begin)))
+        || !(iovec_begin = wasm_runtime_malloc((uint32)total_size)))
         return (wasi_errno_t)-1;
 
     iovec = iovec_begin;
@@ -380,7 +379,7 @@ wasi_fd_pread(wasm_exec_env_t exec_env,
     err = 0;
 
 fail:
-    module_free(mem);
+    wasm_runtime_free(iovec_begin);
     return err;
 }
 
@@ -395,7 +394,6 @@ wasi_fd_pwrite(wasm_exec_env_t exec_env,
     wasi_ciovec_t *ciovec, *ciovec_begin;
     uint64 total_size;
     size_t nwritten;
-    uint32 mem;
     uint32 i;
     wasi_errno_t err;
 
@@ -410,7 +408,7 @@ wasi_fd_pwrite(wasm_exec_env_t exec_env,
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)iovs_len;
     if (total_size >= UINT32_MAX
-        || !(mem = module_malloc((uint32)total_size, (void**)&ciovec_begin)))
+        || !(ciovec_begin = wasm_runtime_malloc((uint32)total_size)))
         return (wasi_errno_t)-1;
 
     ciovec = ciovec_begin;
@@ -435,7 +433,7 @@ wasi_fd_pwrite(wasm_exec_env_t exec_env,
     err = 0;
 
 fail:
-    module_free(mem);
+    wasm_runtime_free(ciovec_begin);
     return err;
 }
 
@@ -451,7 +449,6 @@ wasi_fd_read(wasm_exec_env_t exec_env,
     uint64 total_size;
     size_t nread;
     uint32 i;
-    uint32 mem;
     wasi_errno_t err;
 
     if (!wasi_ctx)
@@ -465,7 +462,7 @@ wasi_fd_read(wasm_exec_env_t exec_env,
 
     total_size = sizeof(wasi_iovec_t) * (uint64)iovs_len;
     if (total_size >= UINT32_MAX
-        || !(mem = module_malloc((uint32)total_size, (void**)&iovec_begin)))
+        || !(iovec_begin = wasm_runtime_malloc((uint32)total_size)))
         return (wasi_errno_t)-1;
 
     iovec = iovec_begin;
@@ -490,7 +487,7 @@ wasi_fd_read(wasm_exec_env_t exec_env,
     err = 0;
 
 fail:
-    module_free(mem);
+    wasm_runtime_free(iovec_begin);
     return err;
 }
 
@@ -622,7 +619,6 @@ wasi_fd_write(wasm_exec_env_t exec_env, wasi_fd_t fd,
     wasi_ciovec_t *ciovec, *ciovec_begin;
     uint64 total_size;
     size_t nwritten;
-    uint32 mem;
     uint32 i;
     wasi_errno_t err;
 
@@ -637,7 +633,7 @@ wasi_fd_write(wasm_exec_env_t exec_env, wasi_fd_t fd,
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)iovs_len;
     if (total_size >= UINT32_MAX
-        || !(mem = module_malloc((uint32)total_size, (void**)&ciovec_begin)))
+        || !(ciovec_begin = wasm_runtime_malloc((uint32)total_size)))
         return (wasi_errno_t)-1;
 
     ciovec = ciovec_begin;
@@ -662,7 +658,7 @@ wasi_fd_write(wasm_exec_env_t exec_env, wasi_fd_t fd,
     err = 0;
 
 fail:
-    module_free(mem);
+    wasm_runtime_free(ciovec_begin);
     return err;
 }
 
@@ -1052,7 +1048,6 @@ wasi_sock_recv(wasm_exec_env_t exec_env,
     wasi_iovec_t *iovec, *iovec_begin;
     uint64 total_size;
     size_t ro_datalen;
-    uint32 mem;
     uint32 i;
     wasi_errno_t err;
 
@@ -1068,7 +1063,7 @@ wasi_sock_recv(wasm_exec_env_t exec_env,
 
     total_size = sizeof(wasi_iovec_t) * (uint64)ri_data_len;
     if (total_size >= UINT32_MAX
-        || !(mem = module_malloc((uint32)total_size, (void**)&iovec_begin)))
+        || !(iovec_begin = wasm_runtime_malloc((uint32)total_size)))
         return (wasi_errno_t)-1;
 
     iovec = iovec_begin;
@@ -1095,7 +1090,7 @@ wasi_sock_recv(wasm_exec_env_t exec_env,
     err = 0;
 
 fail:
-    module_free(mem);
+    wasm_runtime_free(iovec_begin);
     return err;
 }
 
@@ -1112,7 +1107,6 @@ wasi_sock_send(wasm_exec_env_t exec_env,
     wasi_ciovec_t *ciovec, *ciovec_begin;
     uint64 total_size;
     size_t so_datalen;
-    uint32 mem;
     uint32 i;
     wasi_errno_t err;
 
@@ -1127,7 +1121,7 @@ wasi_sock_send(wasm_exec_env_t exec_env,
 
     total_size = sizeof(wasi_ciovec_t) * (uint64)si_data_len;
     if (total_size >= UINT32_MAX
-        || !(mem = module_malloc((uint32)total_size, (void**)&ciovec_begin)))
+        || !(ciovec_begin = wasm_runtime_malloc((uint32)total_size)))
         return (wasi_errno_t)-1;
 
     ciovec = ciovec_begin;
@@ -1153,7 +1147,7 @@ wasi_sock_send(wasm_exec_env_t exec_env,
     err = 0;
 
 fail:
-    module_free(mem);
+    wasm_runtime_free(ciovec_begin);
     return err;
 }
 

--- a/doc/build_wasm_app.md
+++ b/doc/build_wasm_app.md
@@ -64,18 +64,19 @@ There are some useful options which can be specified to build the source code:
 
 - **-Wl,--shared-memory** Use shared linear memory
 
-- **-Wl,--threads** or **-Wl,--no-threads** Run or do not run the linker multi-threaded
-
 - **-Wl,--allow-undefined** Allow undefined symbols in linked binary
 
 - **-Wl,--allow-undefined-file=<value>** Allow symbols listed in <file> to be undefined in linked binary
+
+- **-pthread** Support POSIX threads in generated code
 
 For example, we can build the wasm app with command:
 ``` Bash
 /opt/wasi-sdk/bin/clang -O3 -nostdlib \
     -z stack-size=8192 -Wl,--initial-memory=65536 \
-    -Wl,--export=main -o test.wasm test.c \
-    -Wl,--export=__heap_base,--export=__data_end \
+    -o test.wasm test.c \
+    -Wl,--export=main -Wl,--export=__main_argc_argv \
+    -Wl,--export=__heap_base -Wl,--export=__data_end \
     -Wl,--no-entry -Wl,--strip-all -Wl,--allow-undefined
 ```
 to generate a wasm binary with small footprint.

--- a/product-mini/app-samples/hello-world/build.sh
+++ b/product-mini/app-samples/hello-world/build.sh
@@ -3,13 +3,23 @@
 
 WAMR_DIR=${PWD}/../../..
 
-/opt/wasi-sdk/bin/clang     \
-        --target=wasm32 -O3 \
+echo "Build wasm app .."
+/opt/wasi-sdk/bin/clang -O3 \
         -z stack-size=4096 -Wl,--initial-memory=65536 \
-        --sysroot=${WAMR_DIR}/wamr-sdk/app/libc-builtin-sysroot    \
-        -Wl,--allow-undefined-file=${WAMR_DIR}/wamr-sdk/app/libc-builtin-sysroot/share/defined-symbols.txt \
-        -Wl,--export=main, \
-        -Wl,--export=__data_end, -Wl,--export=__heap_base \
-        -Wl,--no-threads,--strip-all,--no-entry \
-        -nostdlib -o test.wasm *.c
-#./jeffdump -o test_wasm.h -n wasm_test_file test.wasm
+        -o test.wasm main.c \
+        -Wl,--export=main -Wl,--export=__main_argc_argv \
+        -Wl,--export=__data_end -Wl,--export=__heap_base \
+        -Wl,--strip-all,--no-entry \
+        -Wl,--allow-undefined \
+        -nostdlib \
+
+echo "Build binarydump tool .."
+rm -fr build && mkdir build && cd build
+cmake ../../../../test-tools/binarydump-tool
+make
+cd ..
+
+echo "Generate test_wasm.h .."
+./build/binarydump -o test_wasm.h -n wasm_test_file test.wasm
+
+echo "Done"

--- a/samples/basic/build.sh
+++ b/samples/basic/build.sh
@@ -46,7 +46,7 @@ OUT_FILE=${i%.*}.wasm
         --target=wasm32 -O0 -z stack-size=4096 -Wl,--initial-memory=65536 \
         --sysroot=${WAMR_DIR}/wamr-sdk/app/libc-builtin-sysroot  \
         -Wl,--allow-undefined-file=${WAMR_DIR}/wamr-sdk/app/libc-builtin-sysroot/share/defined-symbols.txt \
-        -Wl,--no-threads,--strip-all,--no-entry -nostdlib \
+        -Wl,--strip-all,--no-entry -nostdlib \
         -Wl,--export=generate_float \
         -Wl,--export=float_to_string \
         -Wl,--export=calculate\

--- a/samples/gui/wasm-apps/decrease/Makefile
+++ b/samples/gui/wasm-apps/decrease/Makefile
@@ -21,8 +21,8 @@ all:
     --target=wasm32 -O3 -z stack-size=2048 -Wl,--initial-memory=65536 \
     --sysroot=$(SDK_DIR)/libc-builtin-sysroot       \
     -L$(APP_FRAMEWORK_DIR)/lib -lapp_framework      \
-    -Wl,--allow-undefined-file=$(SDK_DIR)/libc-builtin-sysroot/share/defined-symbols.txt	\
-    -Wl,--no-threads,--strip-all,--no-entry -nostdlib \
+    -Wl,--allow-undefined-file=$(SDK_DIR)/libc-builtin-sysroot/share/defined-symbols.txt \
+    -Wl,--strip-all,--no-entry -nostdlib \
     -Wl,--export=on_init -Wl,--export=on_timer_callback \
     -Wl,--export=on_widget_event \
     -Wl,--export=__heap_base,--export=__data_end \

--- a/samples/gui/wasm-apps/increase/Makefile
+++ b/samples/gui/wasm-apps/increase/Makefile
@@ -27,7 +27,7 @@ all:
 	@$(CC) $(CFLAGS) $(SRCS) \
     --target=wasm32 -O3 -z stack-size=2048 -Wl,--initial-memory=65536 \
     -Wl,--allow-undefined \
-    -Wl,--no-threads,--strip-all,--no-entry -nostdlib \
+    -Wl,--strip-all,--no-entry -nostdlib \
     -Wl,--export=on_init -Wl,--export=on_timer_callback \
     -Wl,--export=on_widget_event \
     -Wl,--export=__heap_base,--export=__data_end \

--- a/samples/littlevgl/wasm-apps/Makefile_wasm_app
+++ b/samples/littlevgl/wasm-apps/Makefile_wasm_app
@@ -49,9 +49,9 @@ all:
 	@$(CC) $(CFLAGS) $(SRCS) \
     -O3 -z stack-size=2048 -Wl,--initial-memory=65536 \
     -DLV_CONF_INCLUDE_SIMPLE                        \
-    -L$(APP_FRAMEWORK_DIR)/lib -lapp_framework		\
+    -L$(APP_FRAMEWORK_DIR)/lib -lapp_framework      \
     -Wl,--allow-undefined                           \
-    -Wl,--no-threads,--strip-all,--no-entry          \
+    -Wl,--strip-all,--no-entry                      \
     -Wl,--export=on_init -Wl,--export=on_timer_callback \
     -Wl,--export=__heap_base,--export=__data_end \
     -o ui_app_wasi.wasm

--- a/samples/littlevgl/wasm-apps/Makefile_wasm_app_no_wasi
+++ b/samples/littlevgl/wasm-apps/Makefile_wasm_app_no_wasi
@@ -52,8 +52,8 @@ all:
     --sysroot=$(WAMR_DIR)/wamr-sdk/app/libc-builtin-sysroot \
     -O3 -z stack-size=2048 -Wl,--initial-memory=65536 \
     -DLV_CONF_INCLUDE_SIMPLE                        \
-    -L$(APP_FRAMEWORK_DIR)/lib -lapp_framework		\
+    -L$(APP_FRAMEWORK_DIR)/lib -lapp_framework      \
     -Wl,--allow-undefined                           \
-    -Wl,--no-threads,--strip-all,--no-entry -nostdlib    \
+    -Wl,--strip-all,--no-entry -nostdlib            \
     -Wl,--export=on_init -Wl,--export=on_timer_callback \
     -o ui_app_builtin_libc.wasm

--- a/samples/multi-thread/wasm-apps/CMakeLists.txt
+++ b/samples/multi-thread/wasm-apps/CMakeLists.txt
@@ -27,11 +27,13 @@ set (DEFINED_SYMBOLS
 "${WAMR_ROOT_DIR}/wamr-sdk/app/libc-builtin-sysroot/share/defined-symbols.txt")
 
 set (CMAKE_EXE_LINKER_FLAGS
-    "-Wl,--shared-memory,--max-memory=131072,       \
-    -Wl,--no-entry,--strip-all,--export=main,       \
-    -Wl,--export=__heap_base,--export=__data_end    \
-    -Wl,--export=__wasm_call_ctors  \
-    -Wl,--allow-undefined-file=${DEFINED_SYMBOLS}"
+     "-Wl,--shared-memory,--max-memory=131072,          \
+      -Wl,--no-entry,--strip-all,                       \
+      -Wl,--export=__heap_base,--export=__data_end      \
+      -Wl,--export=__wasm_call_ctors                    \
+      -Wl,--export=main -Wl,--export=__main_argc_argv   \
+      -Wl,--allow-undefined"
+      #-Wl,--allow-undefined-file=${DEFINED_SYMBOLS}"
 )
 
 add_executable(test.wasm  main.c)

--- a/samples/simple/build.sh
+++ b/samples/simple/build.sh
@@ -153,7 +153,7 @@ OUT_FILE=${i%.*}.wasm
         --target=wasm32 -O3 -z stack-size=4096 -Wl,--initial-memory=65536 \
         --sysroot=${WAMR_DIR}/wamr-sdk/out/$PROFILE/app-sdk/libc-builtin-sysroot  \
         -Wl,--allow-undefined-file=${WAMR_DIR}/wamr-sdk/out/$PROFILE/app-sdk/libc-builtin-sysroot/share/defined-symbols.txt \
-        -Wl,--no-threads,--strip-all,--no-entry -nostdlib \
+        -Wl,--strip-all,--no-entry -nostdlib \
         -Wl,--export=on_init -Wl,--export=on_destroy \
         -Wl,--export=on_request -Wl,--export=on_response \
         -Wl,--export=on_sensor_event -Wl,--export=on_timer_callback \

--- a/test-tools/component_test/suites/01-life-cycle/test-app/build.sh
+++ b/test-tools/component_test/suites/01-life-cycle/test-app/build.sh
@@ -20,11 +20,11 @@ OUT_FILE=${i%.*}.wasm
                         -Wno-int-conversion \
                         -I${APP_FRAMEWORK_DIR}/include \
                         -I${DEPS_DIR} \
-                        --target=wasm32 -O3 -z stack-size=4096 -Wl,--initial-memory=65536 \
-                        --sysroot=${SDK_DIR}/app-sdk/libc-builtin-sysroot       \
-                        -L${APP_FRAMEWORK_DIR}/lib -lapp_framework      \
-                        -Wl,--allow-undefined-file=${SDK_DIR}/app-sdk/libc-builtin-sysroot/share/defined-symbols.txt        \
-                        -Wl,--no-threads,--strip-all,--no-entry -nostdlib \
+                        -O3 -z stack-size=4096 -Wl,--initial-memory=65536 \
+                        --sysroot=${SDK_DIR}/app-sdk/libc-builtin-sysroot \
+                        -L${APP_FRAMEWORK_DIR}/lib -lapp_framework \
+                        -Wl,--allow-undefined-file=${SDK_DIR}/app-sdk/libc-builtin-sysroot/share/defined-symbols.txt \
+                        -Wl,--strip-all,--no-entry -nostdlib \
                         -Wl,--export=on_init -Wl,--export=on_destroy \
                         -Wl,--export=on_request -Wl,--export=on_response \
                         -Wl,--export=on_sensor_event -Wl,--export=on_timer_callback \

--- a/wamr-sdk/app/wamr_toolchain.cmake
+++ b/wamr-sdk/app/wamr_toolchain.cmake
@@ -18,7 +18,7 @@ SET (CMAKE_CXX_COMPILER_TARGET      "wasm32")
 SET (CMAKE_CXX_COMPILER             "${WASI_SDK_DIR}/bin/clang++")
 
 SET (CMAKE_EXE_LINKER_FLAGS
-    "-Wl,--initial-memory=65536,--no-entry,--no-threads,--strip-all" CACHE INTERNAL "")
+    "-Wl,--initial-memory=65536,--no-entry,--strip-all" CACHE INTERNAL "")
 
 SET (CMAKE_LINKER  "${WASI_SDK_DIR}/bin/wasm-ld"                     CACHE INTERNAL "")
 SET (CMAKE_AR      "${WASI_SDK_DIR}/bin/llvm-ar"                     CACHE INTERNAL "")


### PR DESCRIPTION
Update wasm app build scripts for wasi-sdk-12.0: add --export=__main_argc_argv, remove --no-threads
Lookup function with name "__main_argc_argv" as main function besides "main"
Change module_malloc to runtime_malloc in wasi native lib
Refine classic interpreter op_block and op_br_table
Refine faster interpreter op_br_table

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>