### PR TITLE
Add checks to avoid wasm_runtime_malloc memory with size 0 (#507)

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1117,8 +1117,9 @@ load_function_section(const uint8 *buf, const uint8 *buf_end,
     uint64 size, text_offset;
 
     size = sizeof(void*) * (uint64)module->func_count;
-    if (!(module->func_ptrs = loader_malloc
-                (size, error_buf, error_buf_size))) {
+    if (size > 0
+        && !(module->func_ptrs = loader_malloc
+                    (size, error_buf, error_buf_size))) {
         return false;
     }
 
@@ -1158,8 +1159,9 @@ load_function_section(const uint8 *buf, const uint8 *buf_end,
     }
 
     size = sizeof(uint32) * (uint64)module->func_count;
-    if (!(module->func_type_indexes = loader_malloc
-                (size, error_buf, error_buf_size))) {
+    if (size > 0
+        && !(module->func_type_indexes = loader_malloc
+                    (size, error_buf, error_buf_size))) {
         return false;
     }
 
@@ -1498,7 +1500,8 @@ load_relocation_section(const uint8 *buf, const uint8 *buf_end,
 
     /* Allocate memory for relocation groups */
     size = sizeof(AOTRelocationGroup) * (uint64)group_count;
-    if (!(groups = loader_malloc(size, error_buf, error_buf_size))) {
+    if (size > 0
+        && !(groups = loader_malloc(size, error_buf, error_buf_size))) {
         goto fail;
     }
 
@@ -2065,8 +2068,9 @@ aot_load_from_comp_data(AOTCompData *comp_data, AOTCompContext *comp_ctx,
 
     /* Allocate memory for function pointers */
     size = (uint64)module->func_count * sizeof(void *);
-    if (!(module->func_ptrs =
-            loader_malloc(size, error_buf, error_buf_size))) {
+    if (size > 0
+        && !(module->func_ptrs =
+                loader_malloc(size, error_buf, error_buf_size))) {
         goto fail2;
     }
 
@@ -2085,8 +2089,9 @@ aot_load_from_comp_data(AOTCompData *comp_data, AOTCompContext *comp_ctx,
 
     /* Allocation memory for function type indexes */
     size = (uint64)module->func_count * sizeof(uint32);
-    if (!(module->func_type_indexes =
-            loader_malloc(size, error_buf, error_buf_size))) {
+    if (size > 0
+        && !(module->func_type_indexes =
+                loader_malloc(size, error_buf, error_buf_size))) {
         goto fail3;
     }
     for (i = 0; i < comp_data->func_count; i++)
@@ -2135,7 +2140,8 @@ aot_load_from_comp_data(AOTCompData *comp_data, AOTCompContext *comp_ctx,
     return module;
 
 fail3:
-    wasm_runtime_free(module->func_ptrs);
+    if (module->func_ptrs)
+        wasm_runtime_free(module->func_ptrs);
 fail2:
     if (module->memory_count > 0)
         wasm_runtime_free(module->memories);

--- a/core/iwasm/common/wasm_memory.c
+++ b/core/iwasm/common/wasm_memory.c
@@ -161,8 +161,14 @@ wasm_runtime_realloc_internal(void *ptr, unsigned int size)
 static inline void
 wasm_runtime_free_internal(void *ptr)
 {
+    if (!ptr) {
+        LOG_WARNING("warning: wasm_runtime_free with NULL pointer\n");
+        return;
+    }
+
     if (memory_mode == MEMORY_MODE_UNKNOWN) {
-        LOG_WARNING("wasm_runtime_free failed: memory hasn't been initialize.\n");
+        LOG_WARNING("warning: wasm_runtime_free failed: "
+                    "memory hasn't been initialize.\n");
     }
     else if (memory_mode == MEMORY_MODE_POOL) {
         mem_allocator_free(pool_allocator, ptr);
@@ -175,6 +181,12 @@ wasm_runtime_free_internal(void *ptr)
 void *
 wasm_runtime_malloc(unsigned int size)
 {
+    if (size == 0) {
+        LOG_WARNING("warning: wasm_runtime_malloc with size zero\n");
+        /* At lease alloc 1 byte to avoid malloc failed */
+        size = 1;
+    }
+
     return wasm_runtime_malloc_internal(size);
 }
 

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -1712,9 +1712,11 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
 
     total_size = sizeof(char *) * (uint64)argc;
     if (total_size >= UINT32_MAX
-        || !(argv_list = wasm_runtime_malloc((uint32)total_size))
+        || (total_size > 0 &&
+            !(argv_list = wasm_runtime_malloc((uint32)total_size)))
         || argv_buf_size >= UINT32_MAX
-        || !(argv_buf = wasm_runtime_malloc((uint32)argv_buf_size))) {
+        || (argv_buf_size > 0 &&
+            !(argv_buf = wasm_runtime_malloc((uint32)argv_buf_size)))) {
         set_error_buf(error_buf, error_buf_size,
                       "Init wasi environment failed: allocate memory failed");
         goto fail;
@@ -1730,11 +1732,13 @@ wasm_runtime_init_wasi(WASMModuleInstanceCommon *module_inst,
     for (i = 0; i < env_count; i++)
         env_buf_size += strlen(env[i]) + 1;
 
-    total_size = sizeof(char *) * (uint64)argc;
+    total_size = sizeof(char *) * (uint64)env_count;
     if (total_size >= UINT32_MAX
-        || !(env_list = wasm_runtime_malloc((uint32)total_size))
+        || (total_size > 0
+            && !(env_list = wasm_runtime_malloc((uint32)total_size)))
         || env_buf_size >= UINT32_MAX
-        || !(env_buf = wasm_runtime_malloc((uint32)env_buf_size))) {
+        || (env_buf_size > 0
+            && !(env_buf = wasm_runtime_malloc((uint32)env_buf_size)))) {
         set_error_buf(error_buf, error_buf_size,
                       "Init wasi environment failed: allocate memory failed");
         goto fail;
@@ -2842,6 +2846,7 @@ wasm_runtime_invoke_native(WASMExecEnv *exec_env, void *func_ptr,
                         n_stacks++;
                     n_stacks += 2;
                 }
+                break;
 #endif /* BUILD_TARGET_RISCV32_ILP32D */
             default:
                 bh_assert(0);

--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -234,7 +234,7 @@ aot_set_last_error(const char *error);
 void
 aot_set_last_error_v(const char *format, ...);
 
-#if BH_DEBUG == 1
+#if BH_DEBUG != 0
 #define HANDLE_FAILURE(callee) do {                          \
     aot_set_last_error_v("call %s failed in %s:%d", (callee),\
                          __FUNCTION__, __LINE__);            \

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -1751,16 +1751,18 @@ aot_resolve_functions(AOTCompContext *comp_ctx, AOTObjectData *obj_data)
     AOTObjectFunc *func;
     LLVMSymbolIteratorRef sym_itr;
     char *name, *prefix = AOT_FUNC_PREFIX;
-    uint32 func_index;
+    uint32 func_index, total_size;
 
     /* allocate memory for aot function */
     obj_data->func_count = comp_ctx->comp_data->func_count;
-    if (!(obj_data->funcs
-                = wasm_runtime_malloc((uint32)sizeof(AOTObjectFunc) * obj_data->func_count))) {
-        aot_set_last_error("allocate memory for functions failed.");
-        return false;
+    if (obj_data->func_count) {
+        total_size = (uint32)sizeof(AOTObjectFunc) * obj_data->func_count;
+        if (!(obj_data->funcs = wasm_runtime_malloc(total_size))) {
+            aot_set_last_error("allocate memory for functions failed.");
+            return false;
+        }
+        memset(obj_data->funcs, 0, total_size);
     }
-    memset(obj_data->funcs, 0, sizeof(AOTObjectFunc) * obj_data->func_count);
 
     if (!(sym_itr = LLVMObjectFileCopySymbolIterator(obj_data->binary))) {
         aot_set_last_error("llvm get symbol iterator failed.");

--- a/core/iwasm/compilation/aot_emit_function.c
+++ b/core/iwasm/compilation/aot_emit_function.c
@@ -792,7 +792,7 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     uint8 wasm_ret_type, *wasm_ret_types;
     uint64 total_size;
     char buf[32];
-    bool ret;
+    bool ret = false;
 
     /* Check function type index */
     if (type_idx >= comp_ctx->comp_data->func_type_count) {
@@ -1105,13 +1105,15 @@ aot_compile_op_call_indirect(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMPositionBuilderAtEnd(comp_ctx->builder, block_call_import);
 
     /* Allocate memory for result values */
-    total_size = sizeof(LLVMValueRef) * (uint64)func_result_count;
-    if (total_size >= UINT32_MAX
-        || !(value_rets = wasm_runtime_malloc((uint32)total_size))) {
-        aot_set_last_error("allocate memory failed.");
-        goto fail;
+    if (func_result_count > 0) {
+        total_size = sizeof(LLVMValueRef) * (uint64)func_result_count;
+        if (total_size >= UINT32_MAX
+            || !(value_rets = wasm_runtime_malloc((uint32)total_size))) {
+            aot_set_last_error("allocate memory failed.");
+            goto fail;
+        }
+        memset(value_rets, 0, (uint32)total_size);
     }
-    memset(value_rets, 0, total_size);
 
     param_cell_num = func_type->param_cell_num;
     wasm_ret_types = func_type->types + func_type->param_count;

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -103,6 +103,7 @@ typedef struct AOTCheckedAddr {
 
 typedef struct AOTMemInfo {
   LLVMValueRef mem_base_addr;
+  LLVMValueRef mem_data_size_addr;
   LLVMValueRef mem_cur_page_count_addr;
   LLVMValueRef mem_bound_check_1byte;
   LLVMValueRef mem_bound_check_2bytes;

--- a/core/iwasm/compilation/simd/simd_access_lanes.c
+++ b/core/iwasm/compilation/simd/simd_access_lanes.c
@@ -83,7 +83,7 @@ fail:
     return false;
 }
 
-// TODO: instructions for other CPUs
+/* TODO: instructions for other CPUs */
 /* shufflevector is not an option, since it requires *mask as a const */
 bool
 aot_compile_simd_swizzle(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2148,7 +2148,8 @@ load_table_segment_section(const uint8 *buf, const uint8 *buf_end, WASMModule *m
             read_leb_uint32(p, p_end, function_count);
             table_segment->function_count = function_count;
             total_size = sizeof(uint32) * (uint64)function_count;
-            if (!(table_segment->func_indexes = (uint32 *)
+            if (total_size > 0
+                && !(table_segment->func_indexes = (uint32 *)
                     loader_malloc(total_size, error_buf, error_buf_size))) {
                 return false;
             }
@@ -2444,7 +2445,7 @@ handle_name_section(const uint8 *buf, const uint8 *buf_end,
                         previous_func_index = func_index;
                         read_leb_uint32(p, p_end, func_name_len);
                         CHECK_BUF(p, p_end, func_name_len);
-                        // Skip the import functions
+                        /* Skip the import functions */
                         if (func_index >= module->import_count) {
                             func_index -= module->import_count;
                             if (func_index >= module->function_count) {
@@ -5697,7 +5698,7 @@ wasm_loader_prepare_bytecode(WASMModule *module, WASMFunction *func,
     uint32 segment_index;
 #endif
 #if WASM_ENABLE_FAST_INTERP != 0
-    uint8 *func_const_end, *func_const;
+    uint8 *func_const_end, *func_const = NULL;
     int16 operand_offset;
     uint8 last_op = 0;
     bool disable_emit, preserve_local = false;
@@ -7710,7 +7711,8 @@ fail_data_cnt_sec_require:
         goto re_scan;
 
     func->const_cell_num = loader_ctx->const_cell_num;
-    if (!(func->consts = func_const =
+    if (func->const_cell_num > 0
+        && !(func->consts = func_const =
                 loader_malloc(func->const_cell_num * 4,
                               error_buf, error_buf_size))) {
         goto fail;

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1167,7 +1167,8 @@ load_table_segment_section(const uint8 *buf, const uint8 *buf_end, WASMModule *m
             read_leb_uint32(p, p_end, function_count);
             table_segment->function_count = function_count;
             total_size = sizeof(uint32) * (uint64)function_count;
-            if (!(table_segment->func_indexes = (uint32 *)
+            if (total_size > 0
+                && !(table_segment->func_indexes = (uint32 *)
                     loader_malloc(total_size, error_buf, error_buf_size))) {
                 return false;
             }
@@ -1391,7 +1392,7 @@ handle_name_section(const uint8 *buf, const uint8 *buf_end,
                         previous_func_index = func_index;
                         read_leb_uint32(p, p_end, func_name_len);
                         CHECK_BUF(p, p_end, func_name_len);
-                        // Skip the import functions
+                        /* Skip the import functions */
                         if (func_index >= module->import_count) {
                             func_index -= module->import_count;
                             bh_assert(func_index < module->function_count);
@@ -4257,7 +4258,7 @@ wasm_loader_prepare_bytecode(WASMModule *module, WASMFunction *func,
     uint32 segment_index;
 #endif
 #if WASM_ENABLE_FAST_INTERP != 0
-    uint8 *func_const_end, *func_const;
+    uint8 *func_const_end, *func_const = NULL;
     int16 operand_offset;
     uint8 last_op = 0;
     bool disable_emit, preserve_local = false;
@@ -5733,7 +5734,8 @@ handle_op_block_and_loop:
         goto re_scan;
 
     func->const_cell_num = loader_ctx->const_cell_num;
-    if (!(func->consts = func_const =
+    if (func->const_cell_num > 0
+        && !(func->consts = func_const =
                 loader_malloc(func->const_cell_num * 4,
                               error_buf, error_buf_size))) {
         goto fail;

--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c
@@ -1652,7 +1652,8 @@ static __wasi_errno_t path_get_nofollow(
 static void path_put(
     struct path_access *pa
 ) UNLOCKS(pa->fd_object->refcount) {
-  wasm_runtime_free(pa->path_start);
+  if (pa->path_start)
+    wasm_runtime_free(pa->path_start);
   if (fd_number(pa->fd_object) != pa->fd)
     close(pa->fd);
   fd_object_release(pa->fd_object);

--- a/core/shared/utils/bh_log.h
+++ b/core/shared/utils/bh_log.h
@@ -51,7 +51,7 @@ bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...);
 
 #endif
 
-#if BH_DEBUG == 1
+#if BH_DEBUG != 0
 #define LOG_FATAL(...)   bh_log(BH_LOG_LEVEL_FATAL, __FILE__, __LINE__, __VA_ARGS__)
 #else
 #define LOG_FATAL(...)   bh_log(BH_LOG_LEVEL_FATAL, __FUNCTION__, __LINE__, __VA_ARGS__)
@@ -61,7 +61,7 @@ bh_log(LogLevel log_level, const char *file, int line, const char *fmt, ...);
 #define LOG_WARNING(...) bh_log(BH_LOG_LEVEL_WARNING, NULL, 0, __VA_ARGS__)
 #define LOG_VERBOSE(...) bh_log(BH_LOG_LEVEL_VERBOSE, NULL, 0, __VA_ARGS__)
 
-#if BH_DEBUG == 1
+#if BH_DEBUG != 0
 #define LOG_DEBUG(...)   bh_log(BH_LOG_LEVEL_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
 #else
 #define LOG_DEBUG(...)   (void)0

--- a/core/shared/utils/uncommon/bh_read_file.c
+++ b/core/shared/utils/uncommon/bh_read_file.c
@@ -14,7 +14,7 @@ bh_read_file_to_buffer(const char *filename, uint32 *ret_size)
 {
     char *buffer;
     int file;
-    uint32 file_size, read_size;
+    uint32 file_size, buf_size, read_size;
     struct stat stat_buf;
 
     if (!filename || !ret_size) {
@@ -36,7 +36,10 @@ bh_read_file_to_buffer(const char *filename, uint32 *ret_size)
     }
     file_size = (uint32)stat_buf.st_size;
 
-    if (!(buffer = (char *)BH_MALLOC(file_size))) {
+    /* At lease alloc 1 byte to avoid malloc failed */
+    buf_size = file_size > 0 ? file_size : 1;
+
+    if (!(buffer = (char *)BH_MALLOC(buf_size))) {
         printf("Read file to buffer failed: alloc memory failed.\n");
         _close(file);
         return NULL;
@@ -63,7 +66,7 @@ bh_read_file_to_buffer(const char *filename, uint32 *ret_size)
 {
     char *buffer;
     int file;
-    uint32 file_size, read_size;
+    uint32 file_size, buf_size, read_size;
     struct stat stat_buf;
 
     if (!filename || !ret_size) {
@@ -86,7 +89,10 @@ bh_read_file_to_buffer(const char *filename, uint32 *ret_size)
 
     file_size = (uint32)stat_buf.st_size;
 
-    if (!(buffer = BH_MALLOC(file_size))) {
+    /* At lease alloc 1 byte to avoid malloc failed */
+    buf_size = file_size > 0 ? file_size : 1;
+
+    if (!(buffer = BH_MALLOC(buf_size))) {
         printf("Read file to buffer failed: alloc memory failed.\n");
         close(file);
         return NULL;

--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 ## locate wat2wasm
 find_program(WAT2WASM
   wat2wasm
-  PATHS /opt/wabt/bin /opt/wabt-1.0.18/bin
+  PATHS /opt/wabt/bin
   REQUIRED
 )
 

--- a/samples/workload/meshoptimizer/codecbench.patch
+++ b/samples/workload/meshoptimizer/codecbench.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ffdb4da..536a5c8 100644
+index ffdb4da..a397427 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -127,3 +127,43 @@ install(FILES
@@ -24,7 +24,7 @@ index ffdb4da..536a5c8 100644
 +
 +target_link_options(codecbench
 +  PUBLIC
-+    LINKER:-allow-undefined,--demangle
++    LINKER:-allow-undefined,--demangle,--export=malloc,--export=free
 +)
 +
 +find_program(WASM_OPT


### PR DESCRIPTION
In some platforms, allocating memory with size 0 may return NULL but not an empty memory block, which causes runtime load, instantiate or execute wasm/aot file failed. We add checks to try to avoid allocating memory in runtime if the size is 0. And in wasm_runtime_malloc/free, output warning if allocate memory with size 0 and free memory with NULL ptr.
Also fix some coding style issues, fix handle riscv32 ilp32d issue, and fix several wasm-c-api issues.

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>