### PR TITLE
Fix duplicated destroy shared memory's lock issue (#514)

### DIFF
--- a/core/iwasm/common/wasm_native.c
+++ b/core/iwasm/common/wasm_native.c
@@ -21,7 +21,6 @@
 #endif
 
 static NativeSymbolsList g_native_symbols_list = NULL;
-static NativeSymbolsList g_native_symbols_list_end = NULL;
 
 uint32
 get_libc_builtin_export_apis(NativeSymbol **p_libc_builtin_apis);
@@ -287,15 +286,10 @@ register_natives(const char *module_name,
     node->native_symbols = native_symbols;
     node->n_native_symbols = n_native_symbols;
     node->call_conv_raw = call_conv_raw;
-    node->next = NULL;
 
-    if (g_native_symbols_list_end) {
-        g_native_symbols_list_end->next = node;
-        g_native_symbols_list_end = node;
-    }
-    else {
-        g_native_symbols_list = g_native_symbols_list_end = node;
-    }
+    /* Add to list head */
+    node->next = g_native_symbols_list;
+    g_native_symbols_list = node;
 
 #if ENABLE_SORT_DEBUG != 0
     gettimeofday(&start, NULL);
@@ -417,5 +411,5 @@ wasm_native_destroy()
         node = node_next;
     }
 
-    g_native_symbols_list = g_native_symbols_list_end = NULL;
+    g_native_symbols_list = NULL;
 }

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -92,7 +92,6 @@ memories_deinstantiate(WASMModuleInstance *module_inst,
                     continue;
 #endif
 #if WASM_ENABLE_SHARED_MEMORY != 0
-                os_mutex_destroy(&memories[0]->mem_lock);
                 if (memories[i]->is_shared) {
                     int32 ref_count =
                         shared_memory_dec_reference(
@@ -104,6 +103,7 @@ memories_deinstantiate(WASMModuleInstance *module_inst,
                     if (ref_count > 0)
                         continue;
                 }
+                os_mutex_destroy(&memories[i]->mem_lock);
 #endif
                 if (memories[i]->heap_handle) {
                     mem_allocator_destroy(memories[i]->heap_handle);


### PR DESCRIPTION
And add native symbol node to list head when registering native symbol, so as to lookup developer's registered node firstly when linking.

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>