### PR TITLE
Enhance ems memory allocator (#544)

### DIFF
--- a/core/shared/mem-alloc/ems/ems_alloc.c
+++ b/core/shared/mem-alloc/ems/ems_alloc.c
@@ -570,7 +570,6 @@ gc_realloc_vo_internal(void *vheap, void *ptr, gc_size_t size,
         }
     }
 
-
     hmu = alloc_hmu_ex(heap, tot_size);
     if (!hmu)
         goto finish;
@@ -578,6 +577,7 @@ gc_realloc_vo_internal(void *vheap, void *ptr, gc_size_t size,
     bh_assert(hmu_get_size(hmu) >= tot_size);
     /* the total size allocated may be larger than
        the required size, reset it here */
+    tot_size = hmu_get_size(hmu);
     g_total_malloc += tot_size;
 
     hmu_set_ut(hmu, HMU_VO);
@@ -590,7 +590,6 @@ gc_realloc_vo_internal(void *vheap, void *ptr, gc_size_t size,
     ret = hmu_to_obj(hmu);
 
 finish:
-    os_mutex_unlock(&heap->lock);
 
     if (ret) {
         obj_size = tot_size - HMU_SIZE - OBJ_PREFIX_SIZE - OBJ_SUFFIX_SIZE;
@@ -599,9 +598,13 @@ finish:
             obj_size_old = tot_size_old - HMU_SIZE
                            - OBJ_PREFIX_SIZE - OBJ_SUFFIX_SIZE;
             bh_memcpy_s(ret, obj_size, obj_old, obj_size_old);
-            gc_free_vo(vheap, obj_old);
         }
     }
+
+    os_mutex_unlock(&heap->lock);
+
+    if (ret && obj_old)
+        gc_free_vo(vheap, obj_old);
 
     return ret;
 }


### PR DESCRIPTION
The total size actually allocated by ealloc_hmu() might be larger than the size required to allocate, we reset the total size after allocating, so that if heap verification feature is enabled, the data to verify can be written to the right place of the suffix verification area. And in gc_realloc_vo_internal(), free the heap lock until the original data is copied to new object to return.

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>