### PR TITLE
Fix app manager fail to install large app file issue (#555)

### DIFF
--- a/core/app-mgr/app-manager/app_manager.c
+++ b/core/app-mgr/app-manager/app_manager.c
@@ -32,8 +32,8 @@ void app_manager_post_applets_update_event()
         return;
 
     if (!(attr_cont = attr_container_create("All Applets"))) {
-        app_manager_printf(
-                "Post applets update event failed: allocate memory failed.");
+        app_manager_printf("Post applets update event failed: "
+                           "allocate memory failed.");
         return;
     }
 
@@ -46,8 +46,8 @@ void app_manager_post_applets_update_event()
     }
 
     if (!(attr_container_set_int(&attr_cont, "num", num))) {
-        app_manager_printf(
-                "Post applets update event failed: set attr container key failed.");
+        app_manager_printf("Post applets update event failed: "
+                           "set attr container key failed.");
         goto fail;
     }
 
@@ -57,14 +57,14 @@ void app_manager_post_applets_update_event()
         i++;
         snprintf(buf, sizeof(buf), "%s%d", "applet", i);
         if (!(attr_container_set_string(&attr_cont, buf, m_data->module_name))) {
-            app_manager_printf(
-                    "Post applets update event failed: set attr applet name key failed.");
+            app_manager_printf("Post applets update event failed: "
+                               "set attr applet name key failed.");
             goto fail;
         }
         snprintf(buf, sizeof(buf), "%s%d", "heap", i);
         if (!(attr_container_set_int(&attr_cont, buf, m_data->heap_size))) {
-            app_manager_printf(
-                    "Post applets update event failed: set attr heap key failed.");
+            app_manager_printf("Post applets update event failed: "
+                               "set attr heap key failed.");
             goto fail;
         }
         m_data = m_data->next;
@@ -114,7 +114,7 @@ static bool app_manager_query_applets(request_t *msg, const char *name)
     attr_cont = attr_container_create("Applets Info");
     if (!attr_cont) {
         SEND_ERR_RESPONSE(msg->mid,
-                "Query Applets failed: allocate memory failed.");
+                          "Query Applets failed: allocate memory failed.");
         return false;
     }
 
@@ -128,7 +128,7 @@ static bool app_manager_query_applets(request_t *msg, const char *name)
 
     if (name == NULL && !(attr_container_set_int(&attr_cont, "num", num))) {
         SEND_ERR_RESPONSE(msg->mid,
-                "Query Applets failed: set attr container key failed.");
+                          "Query Applets failed: set attr container key failed.");
         goto fail;
     }
 
@@ -142,26 +142,31 @@ static bool app_manager_query_applets(request_t *msg, const char *name)
             if (!(attr_container_set_string(&attr_cont, buf,
                     m_data->module_name))) {
                 SEND_ERR_RESPONSE(msg->mid,
-                        "Query Applets failed: set attr container key failed.");
+                                  "Query Applets failed: "
+                                  "set attr container key failed.");
                 goto fail;
             }
             snprintf(buf, sizeof(buf), "%s%d", "heap", i);
             if (!(attr_container_set_int(&attr_cont, buf, m_data->heap_size))) {
                 SEND_ERR_RESPONSE(msg->mid,
-                        "Query Applets failed: set attr container heap key failed.");
+                                  "Query Applets failed: "
+                                  "set attr container heap key failed.");
                 goto fail;
             }
-        } else if (!strcmp(name, m_data->module_name)) {
+        }
+        else if (!strcmp(name, m_data->module_name)) {
             found = true;
             if (!(attr_container_set_string(&attr_cont, "name",
                     m_data->module_name))) {
                 SEND_ERR_RESPONSE(msg->mid,
-                        "Query Applet failed: set attr container key failed.");
+                                  "Query Applet failed: "
+                                  "set attr container key failed.");
                 goto fail;
             }
             if (!(attr_container_set_int(&attr_cont, "heap", m_data->heap_size))) {
                 SEND_ERR_RESPONSE(msg->mid,
-                        "Query Applet failed: set attr container heap key failed.");
+                                  "Query Applet failed: "
+                                  "set attr container heap key failed.");
                 goto fail;
             }
         }
@@ -266,7 +271,7 @@ static void app_manager_queue_callback(void *message, void *arg)
                 goto fail;
             }
             if (g_module_interfaces[module_type]
-                    && g_module_interfaces[module_type]->module_install) {
+                && g_module_interfaces[module_type]->module_install) {
                 if (!g_module_interfaces[module_type]->module_install(request))
                     goto fail;
             }
@@ -276,14 +281,13 @@ static void app_manager_queue_callback(void *message, void *arg)
             module_type = get_module_type(request->url + offset);
             if (module_type == -1) {
                 SEND_ERR_RESPONSE(mid,
-                        "Uninstall Applet failed: invalid module type.");
+                                  "Uninstall Applet failed: invalid module type.");
                 goto fail;
             }
 
             if (g_module_interfaces[module_type]
                     && g_module_interfaces[module_type]->module_uninstall) {
-                if (!g_module_interfaces[module_type]->module_uninstall(
-                        request))
+                if (!g_module_interfaces[module_type]->module_uninstall(request))
                     goto fail;
             }
         }
@@ -292,18 +296,19 @@ static void app_manager_queue_callback(void *message, void *arg)
             char name[APP_NAME_MAX_LEN] = { 0 };
             char *properties = request->url + offset;
             find_key_value(properties, strlen(properties), "name", name,
-                    sizeof(name) - 1, '&');
+                           sizeof(name) - 1, '&');
             if (strlen(name) > 0)
                 app_manager_query_applets(request, name);
             else
                 app_manager_query_applets(request, NULL);
-        } else {
+        }
+        else {
             SEND_ERR_RESPONSE(mid, "Invalid request of applet: invalid action");
         }
     }
     /* Event Register/Unregister */
     else if ((offset = check_url_start(request->url, strlen(request->url),
-            "/event/")) > 0) {
+                                       "/event/")) > 0) {
         char url_buf[256] = { 0 };
 
         strncpy(url_buf, request->url + offset, sizeof(url_buf) - 1);
@@ -313,11 +318,12 @@ static void app_manager_queue_callback(void *message, void *arg)
             goto fail;
         }
         send_error_response_to_host(mid, CONTENT_2_05, NULL); /* OK */
-    } else {
+    }
+    else {
         int i;
         for (i = 0; i < Module_Max; i++) {
             if (g_module_interfaces[i]
-                    && g_module_interfaces[i]->module_handle_host_url) {
+                && g_module_interfaces[i]->module_handle_host_url) {
                 if (g_module_interfaces[i]->module_handle_host_url(request))
                     break;
             }
@@ -325,10 +331,8 @@ static void app_manager_queue_callback(void *message, void *arg)
 
     }
 
-    fail:
-
+fail:
     return;
-
 }
 
 static void module_interfaces_init()
@@ -360,7 +364,7 @@ void app_manager_startup(host_interface *interface)
 
     am_register_resource("/app/", targeted_app_request_handler, ID_APP_MGR);
 
-    /*/app/ and /event/ are both processed by applet_mgt_reqeust_handler*/
+    /* /app/ and /event/ are both processed by applet_mgt_reqeust_handler */
     am_register_resource("/applet", applet_mgt_reqeust_handler, ID_APP_MGR);
     am_register_resource("/event/", applet_mgt_reqeust_handler, ID_APP_MGR);
 
@@ -368,6 +372,12 @@ void app_manager_startup(host_interface *interface)
 
     /* Enter loop run */
     bh_queue_enter_loop_run(g_app_mgr_queue, app_manager_queue_callback, NULL);
+
+    /* Destroy registered resources */
+    am_cleanup_registeration(ID_APP_MGR);
+
+    /* Destroy watchdog */
+    watchdog_destroy();
 
 fail2:
     module_data_list_destroy();

--- a/core/app-mgr/app-manager/app_manager_host.c
+++ b/core/app-mgr/app-manager/app_manager_host.c
@@ -13,11 +13,19 @@
 static host_interface host_commu;
 
 /* IMRTLink Two leading bytes */
-static unsigned char leadings[] = { (unsigned char) 0x12, (unsigned char) 0x34 };
+static unsigned char leadings[] = {
+    (unsigned char)0x12,
+    (unsigned char)0x34
+};
 
 /* IMRTLink Receiving Phase */
 typedef enum recv_phase_t {
-    Phase_Non_Start, Phase_Leading, Phase_Type, Phase_Size, Phase_Payload
+    Phase_Non_Start,
+    Phase_Leading,
+    Phase_Type,
+    Phase_Size,
+    Phase_Payload,
+    Phase_Ignoring
 } recv_phase_t;
 
 /* IMRTLink Receive Context */
@@ -74,7 +82,8 @@ static int on_imrt_link_byte_arrive(unsigned char ch, recv_context_t *ctx)
         }
 
         return 0;
-    } else if (ctx->phase == Phase_Leading) {
+    }
+    else if (ctx->phase == Phase_Leading) {
         if (ch == leadings[1]) {
             if (enable_log)
                 app_manager_printf("##On byte arrive: got leading 1\n");
@@ -83,12 +92,14 @@ static int on_imrt_link_byte_arrive(unsigned char ch, recv_context_t *ctx)
             ctx->phase = Phase_Non_Start;
 
         return 0;
-    } else if (ctx->phase == Phase_Type) {
+    }
+    else if (ctx->phase == Phase_Type) {
         if (ctx->size_in_phase++ == 0) {
             if (enable_log)
                 app_manager_printf("##On byte arrive: got type 0\n");
             ctx->message.message_type = ch;
-        } else {
+        }
+        else {
             if (enable_log)
                 app_manager_printf("##On byte arrive: got type 1\n");
             ctx->message.message_type |= (ch << 8);
@@ -98,12 +109,13 @@ static int on_imrt_link_byte_arrive(unsigned char ch, recv_context_t *ctx)
         }
 
         return 0;
-    } else if (ctx->phase == Phase_Size) {
+    }
+    else if (ctx->phase == Phase_Size) {
         unsigned char *p = (unsigned char *) &ctx->message.payload_size;
 
         if (enable_log)
             app_manager_printf("##On byte arrive: got payload_size, byte %d\n",
-                    ctx->size_in_phase);
+                               ctx->size_in_phase);
         p[ctx->size_in_phase++] = ch;
 
         if (ctx->size_in_phase == sizeof(ctx->message.payload_size)) {
@@ -112,7 +124,7 @@ static int on_imrt_link_byte_arrive(unsigned char ch, recv_context_t *ctx)
 
             if (enable_log)
                 app_manager_printf("##On byte arrive: payload_size: %d\n",
-                        ctx->message.payload_size);
+                                   ctx->message.payload_size);
             if (ctx->message.payload) {
                 APP_MGR_FREE(ctx->message.payload);
                 ctx->message.payload = NULL;
@@ -122,14 +134,9 @@ static int on_imrt_link_byte_arrive(unsigned char ch, recv_context_t *ctx)
             if (ctx->message.payload_size == 0) {
                 ctx->phase = Phase_Non_Start;
                 if (enable_log)
-                    app_manager_printf(
-                            "##On byte arrive: receive end, payload_size is 0.\n");
+                    app_manager_printf("##On byte arrive: receive end, "
+                                       "payload_size is 0.\n");
                 return 1;
-            }
-
-            if (ctx->message.payload_size > 1024 * 1024) {
-                ctx->phase = Phase_Non_Start;
-                return 0;
             }
 
             if (ctx->message.message_type != INSTALL_WASM_APP) {
@@ -146,7 +153,8 @@ static int on_imrt_link_byte_arrive(unsigned char ch, recv_context_t *ctx)
         }
 
         return 0;
-    } else if (ctx->phase == Phase_Payload) {
+    }
+    else if (ctx->phase == Phase_Payload) {
         if (ctx->message.message_type == INSTALL_WASM_APP) {
             int received_size;
             module_on_install_request_byte_arrive_func module_on_install =
@@ -162,28 +170,45 @@ static int on_imrt_link_byte_arrive(unsigned char ch, recv_context_t *ctx)
                         ctx->phase = Phase_Non_Start;
                         return 1;
                     }
-                } else {
+                }
+                else {
                     /* receive or handle fail */
-                    ctx->phase = Phase_Non_Start;
-                    ctx->size_in_phase = 0;
+                    if (ctx->size_in_phase < ctx->message.payload_size) {
+                        ctx->phase = Phase_Ignoring;
+                    }
+                    else {
+                        ctx->phase = Phase_Non_Start;
+                        ctx->size_in_phase = 0;
+                    }
                     return 0;
                 }
-                return 0;
-            } else {
+            }
+            else {
                 ctx->phase = Phase_Non_Start;
                 ctx->size_in_phase = 0;
                 return 0;
             }
-        } else {
+        }
+        else {
             ctx->message.payload[ctx->size_in_phase++] = ch;
 
             if (ctx->size_in_phase == ctx->message.payload_size) {
                 ctx->phase = Phase_Non_Start;
                 if (enable_log)
-                    app_manager_printf("##On byte arrive: receive end, payload_size is %d.\n",
+                    app_manager_printf("##On byte arrive: receive end, "
+                                       "payload_size is %d.\n",
                                        ctx->message.payload_size);
                 return 1;
             }
+            return 0;
+        }
+    }
+    else if (ctx->phase == Phase_Ignoring) {
+        ctx->size_in_phase++;
+        if (ctx->size_in_phase == ctx->message.payload_size) {
+            if (ctx->message.payload)
+                APP_MGR_FREE(ctx->message.payload);
+            memset(ctx, 0, sizeof(*ctx));
             return 0;
         }
     }
@@ -191,7 +216,7 @@ static int on_imrt_link_byte_arrive(unsigned char ch, recv_context_t *ctx)
     return 0;
 }
 
-int aee_host_msg_callback(void *msg, uint16_t msg_len)
+int aee_host_msg_callback(void *msg, uint32_t msg_len)
 {
     unsigned char *p = msg, *p_end = p + msg_len;
 
@@ -259,8 +284,8 @@ int app_manager_host_send_msg(int msg_type, const char *buf, int size)
         bh_memcpy_s(header, 2, leadings, 2);
 
         /* message type */
-        // todo: check if use network byte order!!!
-        *((uint16*) (header + 2)) = htons(msg_type);
+        /* TODO: check if use network byte order!!! */
+        *((uint16*)(header + 2)) = htons(msg_type);
 
         /* payload length */
         if (is_little_endian())
@@ -279,7 +304,8 @@ int app_manager_host_send_msg(int msg_type, const char *buf, int size)
 
         app_manager_printf("sent %d bytes to host\n", n);
         return n;
-    } else {
+    }
+    else {
         app_manager_printf("no send api provided\n");
     }
     return 0;

--- a/core/app-mgr/app-manager/resource_reg.c
+++ b/core/app-mgr/app-manager/resource_reg.c
@@ -136,7 +136,8 @@ void * am_dispatch_request(request_t *request)
 }
 
 bool am_register_resource(const char *url,
-        void (*request_handler)(request_t *, void *), uint32 register_id)
+                          void (*request_handler)(request_t *, void *),
+                          uint32 register_id)
 {
     app_res_register_t * r = g_resources;
     int register_num = 0;
@@ -158,7 +159,7 @@ bool am_register_resource(const char *url,
     if (register_num >= RESOURCE_REGISTRATION_NUM_MAX)
         return false;
 
-    r = (app_res_register_t *) APP_MGR_MALLOC(sizeof(app_res_register_t));
+    r = (app_res_register_t *)APP_MGR_MALLOC(sizeof(app_res_register_t));
     if (r == NULL)
         return false;
 

--- a/core/app-mgr/app-manager/watchdog.c
+++ b/core/app-mgr/app-manager/watchdog.c
@@ -124,3 +124,9 @@ bool watchdog_startup()
 #endif
     return true;
 }
+
+bool watchdog_destroy()
+{
+    bh_queue_exit_loop_run(watchdog_queue);
+    bh_queue_destroy(watchdog_queue);
+}

--- a/core/app-mgr/app-manager/watchdog.h
+++ b/core/app-mgr/app-manager/watchdog.h
@@ -31,6 +31,9 @@ app_manager_get_watchdog_timer(void *timer);
 bool
 watchdog_startup();
 
+bool
+watchdog_destroy();
+
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif

--- a/core/shared/mem-alloc/ems/ems_alloc.c
+++ b/core/shared/mem-alloc/ems/ems_alloc.c
@@ -570,6 +570,7 @@ gc_realloc_vo_internal(void *vheap, void *ptr, gc_size_t size,
         }
     }
 
+
     hmu = alloc_hmu_ex(heap, tot_size);
     if (!hmu)
         goto finish;

--- a/samples/gui/wasm-runtime-wgl/src/platform/linux/iwasm_main.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/linux/iwasm_main.c
@@ -48,7 +48,7 @@ static int baudrate = B115200;
 extern void init_sensor_framework();
 extern void exit_sensor_framework();
 extern void exit_connection_framework();
-extern int aee_host_msg_callback(void *msg, uint16_t msg_len);
+extern int aee_host_msg_callback(void *msg, uint32_t msg_len);
 extern bool init_connection_framework();
 
 #ifndef CONNECTION_UART

--- a/samples/gui/wasm-runtime-wgl/src/platform/zephyr/iwasm_main.c
+++ b/samples/gui/wasm-runtime-wgl/src/platform/zephyr/iwasm_main.c
@@ -18,7 +18,7 @@
 
 extern void init_sensor_framework();
 extern void exit_sensor_framework();
-extern int aee_host_msg_callback(void *msg, uint16_t msg_len);
+extern int aee_host_msg_callback(void *msg, uint32_t msg_len);
 extern bool touchscreen_read(lv_indev_data_t * data);
 extern int ili9340_init();
 extern void xpt2046_init(void);

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/linux/iwasm_main.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/linux/iwasm_main.c
@@ -46,7 +46,7 @@ static int baudrate = B115200;
 extern void init_sensor_framework();
 extern void exit_sensor_framework();
 extern void exit_connection_framework();
-extern int aee_host_msg_callback(void *msg, uint16_t msg_len);
+extern int aee_host_msg_callback(void *msg, uint32_t msg_len);
 extern bool init_connection_framework();
 
 #ifndef CONNECTION_UART

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/iwasm_main.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/iwasm_main.c
@@ -23,7 +23,7 @@
 
 extern void init_sensor_framework();
 extern void exit_sensor_framework();
-extern int aee_host_msg_callback(void *msg, uint16_t msg_len);
+extern int aee_host_msg_callback(void *msg, uint32_t msg_len);
 
 int uart_char_cnt = 0;
 

--- a/samples/simple/src/iwasm_main.c
+++ b/samples/simple/src/iwasm_main.c
@@ -44,7 +44,7 @@ static int baudrate = B115200;
 extern void init_sensor_framework();
 extern void exit_sensor_framework();
 extern void exit_connection_framework();
-extern int aee_host_msg_callback(void *msg, uint16_t msg_len);
+extern int aee_host_msg_callback(void *msg, uint32_t msg_len);
 extern bool init_connection_framework();
 
 #ifndef CONNECTION_UART

--- a/test-tools/host-tool/src/transport.c
+++ b/test-tools/host-tool/src/transport.c
@@ -115,7 +115,6 @@ bool uart_init(const char *device, int baudrate, int *fd)
     }
 
     *fd = uart_fd;
-
     return true;
 }
 
@@ -133,11 +132,10 @@ bool udp_send(const char *address, int port, const char *buf, int len)
     servaddr.sin_port = htons(port);
     servaddr.sin_addr.s_addr = INADDR_ANY;
 
-    sendto(sockfd, buf, len, MSG_CONFIRM, (const struct sockaddr *) &servaddr,
-        sizeof(servaddr));
+    sendto(sockfd, buf, len, MSG_CONFIRM,
+           (const struct sockaddr *)&servaddr, sizeof(servaddr));
 
     close(sockfd);
-
     return true;
 }
 
@@ -150,7 +148,8 @@ bool host_tool_send_data(int fd, const char *buf, unsigned int len)
         return false;
     }
 
-    resend: ret = write(fd, buf, len);
+resend:
+    ret = write(fd, buf, len);
 
     if (ret == -1) {
         if (errno == ECONNRESET) {
@@ -192,17 +191,21 @@ int on_imrt_link_byte_arrive(unsigned char ch, imrt_link_recv_context_t *ctx)
 
         if (leading[0] == ch) {
             ctx->phase = Phase_Leading;
-        } else {
+        }
+        else {
             return -1;
         }
-    } else if (ctx->phase == Phase_Leading) {
+    }
+    else if (ctx->phase == Phase_Leading) {
         if (leading[1] == ch) {
             SET_RECV_PHASE(ctx, Phase_Type);
-        } else {
+        }
+        else {
             ctx->phase = Phase_Non_Start;
             return -1;
         }
-    } else if (ctx->phase == Phase_Type) {
+    }
+    else if (ctx->phase == Phase_Type) {
         unsigned char *p = (unsigned char *) &ctx->message.message_type;
         p[ctx->size_in_phase++] = ch;
 
@@ -210,7 +213,8 @@ int on_imrt_link_byte_arrive(unsigned char ch, imrt_link_recv_context_t *ctx)
             ctx->message.message_type = ntohs(ctx->message.message_type);
             SET_RECV_PHASE(ctx, Phase_Size);
         }
-    } else if (ctx->phase == Phase_Size) {
+    }
+    else if (ctx->phase == Phase_Size) {
         unsigned char * p = (unsigned char *) &ctx->message.payload_size;
         p[ctx->size_in_phase++] = ch;
 
@@ -237,7 +241,8 @@ int on_imrt_link_byte_arrive(unsigned char ch, imrt_link_recv_context_t *ctx)
             ctx->message.payload = (char *) malloc(ctx->message.payload_size);
             SET_RECV_PHASE(ctx, Phase_Payload);
         }
-    } else if (ctx->phase == Phase_Payload) {
+    }
+    else if (ctx->phase == Phase_Payload) {
         ctx->message.payload[ctx->size_in_phase++] = ch;
 
         if (ctx->size_in_phase == ctx->message.payload_size) {


### PR DESCRIPTION
Remove the limit of app file size no larger than 1 MB, fix possible memory leak issues when fail to install app file, change message size of aee_host_msg_callback() from uint16 type to uint32 type to fix possible integer overflow issue, and fix some coding style issues of app manager.

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>