### PR TITLE
Enable to use BH_VPRINTF macro to redirect stdout output (#560)

### DIFF
--- a/build-scripts/config_common.cmake
+++ b/build-scripts/config_common.cmake
@@ -202,4 +202,7 @@ if (WAMR_BUILD_TAIL_CALL EQUAL 1)
   add_definitions (-DWASM_ENABLE_TAIL_CALL=1)
   message ("     Tail call enabled")
 endif ()
+if (DEFINED WAMR_BH_VPRINTF)
+    add_definitions (-DBH_VPRINTF=${WAMR_BH_VPRINTF})
+endif ()
 

--- a/core/shared/platform/darwin/platform_init.c
+++ b/core/shared/platform/darwin/platform_init.c
@@ -23,7 +23,11 @@ os_printf(const char *format, ...)
     va_list ap;
 
     va_start(ap, format);
+#ifndef BH_VPRINTF
     ret += vprintf(format, ap);
+#else
+    ret += BH_VPRINTF(format, ap);
+#endif
     va_end(ap);
 
     return ret;
@@ -32,6 +36,10 @@ os_printf(const char *format, ...)
 int
 os_vprintf(const char *format, va_list ap)
 {
+#ifndef BH_VPRINTF
     return vprintf(format, ap);
+#else
+    return BH_VPRINTF(format, ap);
+#endif
 }
 

--- a/core/shared/platform/include/platform_common.h
+++ b/core/shared/platform/include/platform_common.h
@@ -34,11 +34,19 @@ extern "C" {
 #endif
 
 #if defined(MSVC)
-__declspec(dllimport)  void *BH_MALLOC(unsigned int size);
-__declspec(dllimport)  void BH_FREE(void *ptr);
+__declspec(dllimport) void *BH_MALLOC(unsigned int size);
+__declspec(dllimport) void BH_FREE(void *ptr);
 #else
 void *BH_MALLOC(unsigned int size);
 void BH_FREE(void *ptr);
+#endif
+
+#if defined(BH_VPRINTF)
+#if defined(MSVC)
+__declspec(dllimport) int BH_VPRINTF(const char *format, va_list ap);
+#else
+int BH_VPRINTF(const char *format, va_list ap);
+#endif
 #endif
 
 #ifndef NULL

--- a/core/shared/platform/linux/platform_init.c
+++ b/core/shared/platform/linux/platform_init.c
@@ -23,7 +23,11 @@ os_printf(const char *format, ...)
     va_list ap;
 
     va_start(ap, format);
+#ifndef BH_VPRINTF
     ret += vprintf(format, ap);
+#else
+    ret += BH_VPRINTF(format, ap);
+#endif
     va_end(ap);
 
     return ret;
@@ -32,6 +36,10 @@ os_printf(const char *format, ...)
 int
 os_vprintf(const char *format, va_list ap)
 {
+#ifndef BH_VPRINTF
     return vprintf(format, ap);
+#else
+    return BH_VPRINTF(format, ap);
+#endif
 }
 

--- a/core/shared/platform/vxworks/platform_init.c
+++ b/core/shared/platform/vxworks/platform_init.c
@@ -23,7 +23,11 @@ os_printf(const char *format, ...)
     va_list ap;
 
     va_start(ap, format);
+#ifndef BH_VPRINTF
     ret += vprintf(format, ap);
+#else
+    ret += BH_VPRINTF(format, ap);
+#endif
     va_end(ap);
 
     return ret;
@@ -32,6 +36,10 @@ os_printf(const char *format, ...)
 int
 os_vprintf(const char *format, va_list ap)
 {
+#ifndef BH_VPRINTF
     return vprintf(format, ap);
+#else
+    return BH_VPRINTF(format, ap);
+#endif
 }
 

--- a/core/shared/platform/windows/platform_init.c
+++ b/core/shared/platform/windows/platform_init.c
@@ -16,3 +16,30 @@ bh_platform_destroy()
 {
 }
 
+int
+os_printf(const char *format, ...)
+{
+    int ret = 0;
+    va_list ap;
+
+    va_start(ap, format);
+#ifndef BH_VPRINTF
+    ret += vprintf(format, ap);
+#else
+    ret += BH_VPRINTF(format, ap);
+#endif
+    va_end(ap);
+
+    return ret;
+}
+
+int
+os_vprintf(const char *format, va_list ap)
+{
+#ifndef BH_VPRINTF
+    return vprintf(format, ap);
+#else
+    return BH_VPRINTF(format, ap);
+#endif
+}
+

--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -49,9 +49,6 @@ typedef struct {
     unsigned int waiting_count;
 } korp_cond;
 
-#define os_printf printf
-#define os_vprintf vprintf
-
 static inline size_t
 getpagesize()
 {

--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -114,6 +114,27 @@ Currently we only profile the memory consumption of module, module_instance and 
 - **WAMR_APP_THREAD_STACK_SIZE_MAX**=n, default to 8 MB (8388608) if not set
 > Note: the AOT boundary check with hardware trap mechanism might consume large stack since the OS may lazily grow the stack mapping as a guard page is hit, we may use this configuration to reduce the total stack usage, e.g. -DWAMR_APP_THREAD_STACK_SIZE_MAX=131072 (128 KB).
 
+#### **WAMR_BH_VPRINTF**=<vprintf_callback>, default to disable if not set
+> Note: if the vprintf_callback function is provided by developer, the os_printf() and os_vprintf() in Linux, Darwin, Windows and VxWorks platforms, besides WASI Libc output will call the callback function instead of libc vprintf() function to redirect the stdout output. For example, developer can define the callback function like below outside runtime lib:
+>
+> ```C
+> int my_vprintf(const char *format, va_list ap)
+> {
+>     /* output to pre-opened file stream */
+>     FILE *my_file = ...;
+>     return vfprintf(my_file, format, ap);
+>     /* or output to pre-opened file descriptor */
+>     int my_fd = ...;
+>     return vdprintf(my_fd, format, ap);
+>     /* or output to string buffer and print the string */
+>     char buf[128];
+>     vsnprintf(buf, sizeof(buf), format, ap);
+>     return my_printf("%s", buf);
+> }
+> ```
+>
+> and then use `cmake -DWAMR_BH_VPRINTF=my_vprintf ..` to pass the callback function, or add `BH_VPRINTF=my_vprintf` macro for the compiler, e.g. add line `add_defintions(-DBH_VPRINTF=my_vprintf)` in CMakeListst.txt.
+
 **Combination of configurations:**
 
 We can combine the configurations. For example, if we want to disable interpreter, enable AOT and WASI, we can run command:


### PR DESCRIPTION
Enable to use BH_VPRINTF macro for platform Linux/Windows/Darwin/VxWorks to redirect the stdout output from platform os_printf/os_vprintf, or the wasi output from wasm app to the vprintf like callback function specified by BH_VPRINTF macro of cmake WAMR_BH_VPRINTF variable.

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>