### PR TITLE
Fix interpreter not update memory size after call native func (#563)

### DIFF
--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1868,7 +1868,7 @@ label_pop_csp_n:
         else {
           /* success, return previous page count */
           PUSH_I32(prev_page_count);
-          /* update the memory instance ptr */
+          /* update memory instance ptr and memory size */
           memory = module->default_memory;
           linear_mem_size = num_bytes_per_page * memory->cur_page_count;
         }
@@ -3209,7 +3209,10 @@ label_pop_csp_n:
           cur_func = frame->function;
           UPDATE_ALL_FROM_FRAME();
 
+          /* update memory instance ptr and memory size */
           memory = module->default_memory;
+          if (memory)
+             linear_mem_size = num_bytes_per_page * memory->cur_page_count;
           if (wasm_get_exception(module))
               goto got_exception;
       }

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1784,7 +1784,7 @@ recover_br_info:
         else {
           /* success, return previous page count */
           frame_lp[addr_ret] = prev_page_count;
-          /* update the memory instance ptr */
+          /* update memory instance ptr and memory size */
           memory = module->default_memory;
           linear_mem_size = num_bytes_per_page * memory->cur_page_count;
         }
@@ -3257,7 +3257,10 @@ recover_br_info:
           cur_func = frame->function;
           UPDATE_ALL_FROM_FRAME();
 
+          /* update memory instance ptr and memory size */
           memory = module->default_memory;
+          if (memory)
+              linear_mem_size = num_bytes_per_page * memory->cur_page_count;
           if (wasm_get_exception(module))
               goto got_exception;
       }

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/XPT2046.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/XPT2046.c
@@ -72,8 +72,9 @@ K_MUTEX_DEFINE( spi_display_touch_mutex);
 int cnt = 0;
 int touch_read_times = 0;
 int last_pen_interrupt_time = 0;
+
 void xpt2046_pen_gpio_callback(struct device *port, struct gpio_callback *cb,
-        u32_t pins)
+                               uint32_t pins)
 {
     cnt++;
     if ((k_uptime_get_32() - last_pen_interrupt_time) > 500) {

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display.h
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display.h
@@ -28,9 +28,11 @@ extern "C" {
 #endif
 
 enum display_pixel_format {
-    PIXEL_FORMAT_RGB_888 = BIT(0), PIXEL_FORMAT_MONO01 = BIT(1), /* 0=Black 1=White */
+    PIXEL_FORMAT_RGB_888 = BIT(0),
+    PIXEL_FORMAT_MONO01 = BIT(1), /* 0=Black 1=White */
     PIXEL_FORMAT_MONO10 = BIT(2), /* 1=Black 0=White */
-    PIXEL_FORMAT_ARGB_8888 = BIT(3), PIXEL_FORMAT_RGB_565 = BIT(4),
+    PIXEL_FORMAT_ARGB_8888 = BIT(3),
+    PIXEL_FORMAT_RGB_565 = BIT(4),
 };
 
 enum display_screen_info {
@@ -90,10 +92,10 @@ enum display_orientation {
  *
  */
 struct display_capabilities {
-    u16_t x_resolution;
-    u16_t y_resolution;
-    u32_t supported_pixel_formats;
-    u32_t screen_info;
+    uint16_t x_resolution;
+    uint16_t y_resolution;
+    uint32_t supported_pixel_formats;
+    uint32_t screen_info;
     enum display_pixel_format current_pixel_format;
     enum display_orientation current_orientation;
 };
@@ -116,10 +118,10 @@ struct display_capabilities {
  *
  */
 struct display_buffer_descriptor {
-    u32_t buf_size;
-    u16_t width;
-    u16_t height;
-    u16_t pitch;
+    uint32_t buf_size;
+    uint16_t width;
+    uint16_t height;
+    uint16_t pitch;
 };
 
 /**
@@ -141,17 +143,20 @@ typedef int (*display_blanking_off_api)(const struct device *dev);
  * @brief Callback API for writing data to the display
  * See display_write() for argument description
  */
-typedef int (*display_write_api)(const struct device *dev, const u16_t x,
-        const u16_t y, const struct display_buffer_descriptor *desc,
-        const void *buf);
+typedef int (*display_write_api)(const struct device *dev,
+                                 const uint16_t x, const uint16_t y,
+                                 const struct display_buffer_descriptor *desc,
+                                 const void *buf);
 
 /**
  * @typedef display_read_api
  * @brief Callback API for reading data from the display
  * See display_read() for argument description
  */
-typedef int (*display_read_api)(const struct device *dev, const u16_t x,
-        const u16_t y, const struct display_buffer_descriptor *desc, void *buf);
+typedef int (*display_read_api)(const struct device *dev,
+                                const uint16_t x, const uint16_t y,
+                                const struct display_buffer_descriptor *desc,
+                                void *buf);
 
 /**
  * @typedef display_get_framebuffer_api
@@ -166,7 +171,7 @@ typedef void *(*display_get_framebuffer_api)(const struct device *dev);
  * See display_set_brightness() for argument description
  */
 typedef int (*display_set_brightness_api)(const struct device *dev,
-        const u8_t brightness);
+                                          const uint8_t brightness);
 
 /**
  * @typedef display_set_contrast_api
@@ -174,7 +179,7 @@ typedef int (*display_set_brightness_api)(const struct device *dev,
  * See display_set_contrast() for argument description
  */
 typedef int (*display_set_contrast_api)(const struct device *dev,
-        const u8_t contrast);
+                                        const uint8_t contrast);
 
 /**
  * @typedef display_get_capabilities_api
@@ -182,7 +187,7 @@ typedef int (*display_set_contrast_api)(const struct device *dev,
  * See display_get_capabilities() for argument description
  */
 typedef void (*display_get_capabilities_api)(const struct device *dev,
-        struct display_capabilities * capabilities);
+                                             struct display_capabilities * capabilities);
 
 /**
  * @typedef display_set_pixel_format_api
@@ -190,7 +195,7 @@ typedef void (*display_get_capabilities_api)(const struct device *dev,
  * See display_set_pixel_format() for argument description
  */
 typedef int (*display_set_pixel_format_api)(const struct device *dev,
-        const enum display_pixel_format pixel_format);
+                                            const enum display_pixel_format pixel_format);
 
 /**
  * @typedef display_set_orientation_api
@@ -198,7 +203,7 @@ typedef int (*display_set_pixel_format_api)(const struct device *dev,
  * See display_set_orientation() for argument description
  */
 typedef int (*display_set_orientation_api)(const struct device *dev,
-        const enum display_orientation orientation);
+                                           const enum display_orientation orientation);
 
 /**
  * @brief Display driver API
@@ -229,9 +234,9 @@ extern struct display_driver_api ili9340_api1;
  *
  * @retval 0 on success else negative errno code.
  */
-static inline int display_write(const struct device *dev, const u16_t x,
-        const u16_t y, const struct display_buffer_descriptor *desc,
-        const void *buf)
+static inline int
+display_write(const struct device *dev, const uint16_t x, const uint16_t y,
+              const struct display_buffer_descriptor *desc, const void *buf)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;
@@ -250,8 +255,9 @@ static inline int display_write(const struct device *dev, const u16_t x,
  *
  * @retval 0 on success else negative errno code.
  */
-static inline int display_read(const struct device *dev, const u16_t x,
-        const u16_t y, const struct display_buffer_descriptor *desc, void *buf)
+static inline int
+display_read(const struct device *dev, const uint16_t x, const uint16_t y,
+             const struct display_buffer_descriptor *desc, void *buf)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;
@@ -268,7 +274,8 @@ static inline int display_read(const struct device *dev, const u16_t x,
  * is not supported
  *
  */
-static inline void *display_get_framebuffer(const struct device *dev)
+static inline void *
+display_get_framebuffer(const struct device *dev)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;
@@ -283,7 +290,8 @@ static inline void *display_get_framebuffer(const struct device *dev)
  *
  * @retval 0 on success else negative errno code.
  */
-static inline int display_blanking_on(const struct device *dev)
+static inline int
+display_blanking_on(const struct device *dev)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;
@@ -298,7 +306,8 @@ static inline int display_blanking_on(const struct device *dev)
  *
  * @retval 0 on success else negative errno code.
  */
-static inline int display_blanking_off(const struct device *dev)
+static inline int
+display_blanking_off(const struct device *dev)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;
@@ -317,8 +326,8 @@ static inline int display_blanking_off(const struct device *dev)
  *
  * @retval 0 on success else negative errno code.
  */
-static inline int display_set_brightness(const struct device *dev,
-        u8_t brightness)
+static inline int
+display_set_brightness(const struct device *dev, uint8_t brightness)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;
@@ -337,7 +346,8 @@ static inline int display_set_brightness(const struct device *dev,
  *
  * @retval 0 on success else negative errno code.
  */
-static inline int display_set_contrast(const struct device *dev, u8_t contrast)
+static inline int
+display_set_contrast(const struct device *dev, uint8_t contrast)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;
@@ -351,8 +361,9 @@ static inline int display_set_contrast(const struct device *dev, u8_t contrast)
  * @param dev Pointer to device structure
  * @param capabilities Pointer to capabilities structure to populate
  */
-static inline void display_get_capabilities(const struct device *dev,
-        struct display_capabilities * capabilities)
+static inline void
+display_get_capabilities(const struct device *dev,
+                         struct display_capabilities * capabilities)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;
@@ -368,8 +379,9 @@ static inline void display_get_capabilities(const struct device *dev,
  *
  * @retval 0 on success else negative errno code.
  */
-static inline int display_set_pixel_format(const struct device *dev,
-        const enum display_pixel_format pixel_format)
+static inline int
+display_set_pixel_format(const struct device *dev,
+                         const enum display_pixel_format pixel_format)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;
@@ -385,8 +397,9 @@ static inline int display_set_pixel_format(const struct device *dev,
  *
  * @retval 0 on success else negative errno code.
  */
-static inline int display_set_orientation(const struct device *dev,
-        const enum display_orientation orientation)
+static inline int
+display_set_orientation(const struct device *dev,
+                        const enum display_orientation orientation)
 {
     struct display_driver_api *api = &ili9340_api1;
     //(struct display_driver_api *)dev->driver_api;

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.c
@@ -35,15 +35,18 @@ struct ili9340_data ili9340_data1;
 #define ILI9340_CMD_DATA_PIN_COMMAND 0
 #define ILI9340_CMD_DATA_PIN_DATA 1
 
-static void ili9340_exit_sleep(struct ili9340_data *data)
+static void
+ili9340_exit_sleep(struct ili9340_data *data)
 {
     ili9340_transmit(data, ILI9340_CMD_EXIT_SLEEP, NULL, 0);
     //k_sleep(Z_TIMEOUT_MS(120));
 }
 
-int ili9340_init()
+int
+ili9340_init()
 {
     struct ili9340_data *data = &ili9340_data1;
+
     printf("Initializing display driver\n");
     data->spi_dev = device_get_binding(DT_ILITEK_ILI9340_0_BUS_NAME);
     if (data->spi_dev == NULL) {
@@ -97,10 +100,12 @@ int ili9340_init()
     return 0;
 }
 
-static void ili9340_set_mem_area(struct ili9340_data *data, const u16_t x,
-                                 const u16_t y, const u16_t w, const u16_t h)
+static void
+ili9340_set_mem_area(struct ili9340_data *data,
+                     const uint16_t x, const uint16_t y,
+                     const uint16_t w, const uint16_t h)
 {
-    u16_t spi_data[2];
+    uint16_t spi_data[2];
 
     spi_data[0] = sys_cpu_to_be16(x);
     spi_data[1] = sys_cpu_to_be16(x + w - 1);
@@ -111,16 +116,17 @@ static void ili9340_set_mem_area(struct ili9340_data *data, const u16_t x,
     ili9340_transmit(data, ILI9340_CMD_PAGE_ADDR, &spi_data[0], 4);
 }
 
-static int ili9340_write(const struct device *dev, const u16_t x, const u16_t y,
-                         const struct display_buffer_descriptor *desc, const void *buf)
+static int
+ili9340_write(const struct device *dev, const uint16_t x, const uint16_t y,
+              const struct display_buffer_descriptor *desc, const void *buf)
 {
     struct ili9340_data *data = (struct ili9340_data *) &ili9340_data1;
-    const u8_t *write_data_start = (u8_t *) buf;
+    const uint8_t *write_data_start = (uint8_t *) buf;
     struct spi_buf tx_buf;
     struct spi_buf_set tx_bufs;
-    u16_t write_cnt;
-    u16_t nbr_of_writes;
-    u16_t write_h;
+    uint16_t write_cnt;
+    uint16_t nbr_of_writes;
+    uint16_t write_h;
 
     __ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
     __ASSERT((3 * desc->pitch * desc->height) <= desc->buf_size,
@@ -151,62 +157,69 @@ static int ili9340_write(const struct device *dev, const u16_t x, const u16_t y,
     return 0;
 }
 
-static int ili9340_read(const struct device *dev, const u16_t x, const u16_t y,
-                        const struct display_buffer_descriptor *desc, void *buf)
+static int
+ili9340_read(const struct device *dev, const uint16_t x, const uint16_t y,
+             const struct display_buffer_descriptor *desc, void *buf)
 {
     LOG_ERR("Reading not supported\n");
     return -ENOTSUP;
 }
 
-static void *ili9340_get_framebuffer(const struct device *dev)
+static void *
+ili9340_get_framebuffer(const struct device *dev)
 {
     LOG_ERR("Direct framebuffer access not supported\n");
     return NULL;
 }
 
-static int ili9340_display_blanking_off(const struct device *dev)
+static int
+ili9340_display_blanking_off(const struct device *dev)
 {
-    struct ili9340_data *data = (struct ili9340_data *) dev->driver_data;
+    struct ili9340_data *data = (struct ili9340_data *)dev->data;
 
     LOG_DBG("Turning display blanking off\n");
     ili9340_transmit(data, ILI9340_CMD_DISPLAY_ON, NULL, 0);
     return 0;
 }
 
-static int ili9340_display_blanking_on(const struct device *dev)
+static int
+ili9340_display_blanking_on(const struct device *dev)
 {
-    struct ili9340_data *data = (struct ili9340_data *) dev->driver_data;
+    struct ili9340_data *data = (struct ili9340_data *)dev->data;
 
     LOG_DBG("Turning display blanking on\n");
     ili9340_transmit(data, ILI9340_CMD_DISPLAY_OFF, NULL, 0);
     return 0;
 }
 
-static int ili9340_set_brightness(const struct device *dev,
-                                  const u8_t brightness)
+static int
+ili9340_set_brightness(const struct device *dev, const uint8_t brightness)
 {
     LOG_WRN("Set brightness not implemented\n");
     return -ENOTSUP;
 }
 
-static int ili9340_set_contrast(const struct device *dev, const u8_t contrast)
+static int
+ili9340_set_contrast(const struct device *dev, const uint8_t contrast)
 {
     LOG_ERR("Set contrast not supported\n");
     return -ENOTSUP;
 }
 
-static int ili9340_set_pixel_format(const struct device *dev,
-                                    const enum display_pixel_format pixel_format)
+static int
+ili9340_set_pixel_format(const struct device *dev,
+                         const enum display_pixel_format pixel_format)
 {
     if (pixel_format == PIXEL_FORMAT_RGB_888) {
-    return 0;
-}
+        return 0;
+    }
     LOG_ERR("Pixel format change not implemented\n");
     return -ENOTSUP;
 }
 
-static int ili9340_set_orientation(const struct device *dev,
-                                   const enum display_orientation orientation)
+static int
+ili9340_set_orientation(const struct device *dev,
+                        const enum display_orientation orientation)
 {
     if (orientation == DISPLAY_ORIENTATION_NORMAL) {
         return 0;
@@ -215,8 +228,9 @@ static int ili9340_set_orientation(const struct device *dev,
     return -ENOTSUP;
 }
 
-static void ili9340_get_capabilities(const struct device *dev,
-                                     struct display_capabilities *capabilities)
+static void
+ili9340_get_capabilities(const struct device *dev,
+                         struct display_capabilities *capabilities)
 {
     memset(capabilities, 0, sizeof(struct display_capabilities));
     capabilities->x_resolution = 320;
@@ -226,13 +240,14 @@ static void ili9340_get_capabilities(const struct device *dev,
     capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
 }
 
-void ili9340_transmit(struct ili9340_data *data, u8_t cmd, void *tx_data,
-                      size_t tx_len)
+void
+ili9340_transmit(struct ili9340_data *data, uint8_t cmd,
+                 void *tx_data, size_t tx_len)
 {
-    data = (struct ili9340_data *) &ili9340_data1;
     struct spi_buf tx_buf = { .buf = &cmd, .len = 1 };
     struct spi_buf_set tx_bufs = { .buffers = &tx_buf, .count = 1 };
 
+    data = (struct ili9340_data *) &ili9340_data1;
     gpio_pin_set(data->command_data_gpio, DT_ILITEK_ILI9340_0_CMD_DATA_GPIOS_PIN,
                    ILI9340_CMD_DATA_PIN_COMMAND);
     spi_transceive(data->spi_dev, &data->spi_config, &tx_bufs, NULL);
@@ -260,7 +275,7 @@ struct display_driver_api ili9340_api1 = {
 };
 
 /*
- DEVICE_AND_API_INIT(ili9340, DT_ILITEK_ILI9340_0_LABEL, &ili9340_init,
- &ili9340_data, NULL, APPLICATION,
- CONFIG_APPLICATION_INIT_PRIORITY, &ili9340_api);
- */
+DEVICE_AND_API_INIT(ili9340, DT_ILITEK_ILI9340_0_LABEL, &ili9340_init,
+                    &ili9340_data, NULL, APPLICATION,
+                    CONFIG_APPLICATION_INIT_PRIORITY, &ili9340_api);
+*/

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.h
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.h
@@ -52,8 +52,8 @@ struct ili9340_data;
  * @param tx_len Number of bytes in tx_data buffer
  *
  */
-void ili9340_transmit(struct ili9340_data *data, u8_t cmd, void *tx_data,
-        size_t tx_len);
+void ili9340_transmit(struct ili9340_data *data, uint8_t cmd,
+                      void *tx_data, size_t tx_len);
 
 /**
  * Perform LCD specific initialization

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340_adafruit_1480.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340_adafruit_1480.c
@@ -8,7 +8,7 @@
 
 void ili9340_lcd_init(struct ili9340_data *data)
 {
-    u8_t tx_data[15];
+    uint8_t tx_data[15];
 
     tx_data[0] = 0x23;
     ili9340_transmit(data, ILI9340_CMD_POWER_CTRL_1, tx_data, 1);

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_indev.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_indev.c
@@ -43,8 +43,8 @@ display_flush(wasm_exec_env_t exec_env,
                                            color, sizeof(lv_color_t)))
         return;
 
-    u16_t w = x2 - x1 + 1;
-    u16_t h = y2 - y1 + 1;
+    uint16_t w = x2 - x1 + 1;
+    uint16_t h = y2 - y1 + 1;
 
     desc.buf_size = 3 * w * h;
     desc.width = w;
@@ -93,7 +93,7 @@ display_vdb_write(wasm_exec_env_t exec_env,
                   lv_color_t *color, lv_opa_t opa)
 {
     wasm_module_inst_t module_inst = get_module_inst(exec_env);
-    u8_t *buf_xy = (u8_t*)buf + 3 * x + 3 * y * buf_w;
+    uint8_t *buf_xy = (uint8_t*)buf + 3 * x + 3 * y * buf_w;
 
     if (!wasm_runtime_validate_native_addr(module_inst,
                                            color, sizeof(lv_color_t)))

--- a/samples/workload/tensorflow/tf_lite.patch
+++ b/samples/workload/tensorflow/tf_lite.patch
@@ -1,5 +1,5 @@
 diff --git a/tensorflow/lite/tools/make/Makefile b/tensorflow/lite/tools/make/Makefile
-index c7ddff58440..ed69c452b67 100644
+index c7ddff58440..ebfebaead35 100644
 --- a/tensorflow/lite/tools/make/Makefile
 +++ b/tensorflow/lite/tools/make/Makefile
 @@ -48,11 +48,7 @@ INCLUDES += -I/usr/local/include
@@ -15,7 +15,7 @@ index c7ddff58440..ed69c452b67 100644
  -ldl
  
  # There are no rules for compiling objects for the host system (since we don't
-@@ -84,14 +80,21 @@ endif # ifeq ($(HOST_ARCH),$(TARGET_ARCH))
+@@ -84,14 +80,24 @@ endif # ifeq ($(HOST_ARCH),$(TARGET_ARCH))
  endif # ifeq ($(HOST_OS),$(TARGET))
  endif
  
@@ -23,6 +23,9 @@ index c7ddff58440..ed69c452b67 100644
 +CXXFLAGS+=-msimd128
 +
 +LIBFLAGS += -s TOTAL_STACK=1048576 \
++            -s INITIAL_MEMORY=16777216 \
++            -s MAXIMUM_MEMORY=167772160 \
++            -s ALLOW_MEMORY_GROWTH=1 \
 +            -Wl,--export=__data_end -Wl,--export=__heap_base \
 +            -s ERROR_ON_UNDEFINED_SYMBOLS=0
 +
@@ -39,7 +42,7 @@ index c7ddff58440..ed69c452b67 100644
  
  # A small example program that shows how to link against the library.
  MINIMAL_SRCS := \
-@@ -277,12 +280,16 @@ LIB_PATH := $(LIBDIR)$(LIB_NAME)
+@@ -277,12 +283,16 @@ LIB_PATH := $(LIBDIR)$(LIB_NAME)
  BENCHMARK_LIB := $(LIBDIR)$(BENCHMARK_LIB_NAME)
  BENCHMARK_BINARY := $(BINDIR)$(BENCHMARK_BINARY_NAME)
  BENCHMARK_PERF_OPTIONS_BINARY := $(BINDIR)$(BENCHMARK_PERF_OPTIONS_BINARY_NAME)


### PR DESCRIPTION
The native function might call wasm function exported, in which the memory.grow opcode might be executed, and interpreter should update memory size after that, or load/store opcodes may run failed with "out of bounds memory access" exception thrown.

Update tensorflow sample patch, allow tensorflow wasm app to grow memory so as to run more models. And fix some compile issues of littlevgl zephyr sample for latest zephyr source code.

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>