### PR TITLE
Upgrade llvm version from 10.x to 11.x for wamrc and iwasm JIT (#564)

### DIFF
--- a/doc/build_wamr.md
+++ b/doc/build_wamr.md
@@ -240,6 +240,8 @@ Make sure `MSVC` and `cmake` are installed and available in the command line env
 
 Then build the source codes:
 ``` Bash
+cd core/deps/
+git clone https://github.com/nodejs/uvwasi.git
 cd product-mini/platforms/windows/
 mkdir build
 cd build

--- a/product-mini/platforms/linux/build_llvm.sh
+++ b/product-mini/platforms/linux/build_llvm.sh
@@ -8,7 +8,7 @@ DEPS_DIR=${PWD}/../../../core/deps
 cd ${DEPS_DIR}
 if [ ! -d "llvm" ]; then
   echo "Clone llvm to core/deps/ .."
-  git clone --depth 1 --branch release/10.x https://github.com/llvm/llvm-project.git llvm
+  git clone --depth 1 --branch release/11.x https://github.com/llvm/llvm-project.git llvm
 fi
 
 cd llvm

--- a/wamr-compiler/build_llvm.py
+++ b/wamr-compiler/build_llvm.py
@@ -12,7 +12,7 @@ def clone_llvm():
     llvm_dir = Path("llvm")
     if(llvm_dir.exists() == False):
         print("Clone llvm to core/deps/ ..")
-        for line in os.popen("git clone --branch release/10.x https://github.com/llvm/llvm-project.git llvm"):
+        for line in os.popen("git clone --branch release/11.x https://github.com/llvm/llvm-project.git llvm"):
             print(line)
     else:
         print("llvm source codes already existed")

--- a/wamr-compiler/build_llvm.sh
+++ b/wamr-compiler/build_llvm.sh
@@ -8,7 +8,7 @@ DEPS_DIR=${PWD}/../core/deps
 cd ${DEPS_DIR}
 if [ ! -d "llvm" ]; then
   echo "Clone llvm to core/deps/ .."
-  git clone --depth 1 --branch release/10.x https://github.com/llvm/llvm-project.git llvm
+  git clone --depth 1 --branch release/11.x https://github.com/llvm/llvm-project.git llvm
 fi
 
 cd llvm


### PR DESCRIPTION
Upgrade it as the latest version of wasi-sdk and emsdk are based on llvm-11, align to it to use the same compiler version. And this also fixes compilation error when building wamrc with llvm-10 in Windows platform.

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>