### PR TITLE
Remove heap size check when creating wasi ctx (#565)

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -879,17 +879,16 @@ aot_instantiate(AOTModule *module, bool is_sub_inst,
 
 #if WASM_ENABLE_LIBC_WASI != 0
     if (!is_sub_inst) {
-        if (heap_size > 0
-            && !wasm_runtime_init_wasi((WASMModuleInstanceCommon*)module_inst,
-                                       module->wasi_args.dir_list,
-                                       module->wasi_args.dir_count,
-                                       module->wasi_args.map_dir_list,
-                                       module->wasi_args.map_dir_count,
-                                       module->wasi_args.env,
-                                       module->wasi_args.env_count,
-                                       module->wasi_args.argv,
-                                       module->wasi_args.argc,
-                                       error_buf, error_buf_size))
+        if (!wasm_runtime_init_wasi((WASMModuleInstanceCommon*)module_inst,
+                                    module->wasi_args.dir_list,
+                                    module->wasi_args.dir_count,
+                                    module->wasi_args.map_dir_list,
+                                    module->wasi_args.map_dir_count,
+                                    module->wasi_args.env,
+                                    module->wasi_args.env_count,
+                                    module->wasi_args.argv,
+                                    module->wasi_args.argc,
+                                    error_buf, error_buf_size))
             goto fail;
     }
 #endif

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -3400,8 +3400,21 @@ fail:
 #undef v128
 #endif
 
+#if defined(_WIN32) || defined(_WIN32_)
+typedef union __declspec(intrin_type) __declspec(align(1)) v128 {
+    __int8 m128i_i8[16];
+    __int16 m128i_i16[8];
+    __int32 m128i_i32[4];
+    __int64 m128i_i64[2];
+    unsigned __int8 m128i_u8[16];
+    unsigned __int16 m128i_u16[8];
+    unsigned __int32 m128i_u32[4];
+    unsigned __int64 m128i_u64[2];
+} v128;
+#else
 typedef long long v128 __attribute__ ((__vector_size__ (16),
                                        __may_alias__, __aligned__ (1)));
+#endif /* end of defined(_WIN32) || defined(_WIN32_) */
 
 #endif /* end of WASM_ENABLE_SIMD != 0 */
 

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -333,8 +333,7 @@ wasm_runtime_set_wasi_args(wasm_module_t module,
  *        specified here is ignored.
  * @param heap_size the default heap size of the module instance, a heap will
  *        be created besides the app memory space. Both wasm app and native
- *        function can allocate memory from the heap. If heap_size is 0, the
- *        default heap size will be used.
+ *        function can allocate memory from the heap.
  * @param error_buf buffer to output the error info if failed
  * @param error_buf_size the size of the error buffer
  *

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1411,17 +1411,16 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst,
 #if WASM_ENABLE_LIBC_WASI != 0
     /* The sub-instance will get the wasi_ctx from main-instance */
     if (!is_sub_inst) {
-        if (heap_size > 0
-            && !wasm_runtime_init_wasi((WASMModuleInstanceCommon*)module_inst,
-                                       module->wasi_args.dir_list,
-                                       module->wasi_args.dir_count,
-                                       module->wasi_args.map_dir_list,
-                                       module->wasi_args.map_dir_count,
-                                       module->wasi_args.env,
-                                       module->wasi_args.env_count,
-                                       module->wasi_args.argv,
-                                       module->wasi_args.argc,
-                                       error_buf, error_buf_size)) {
+        if (!wasm_runtime_init_wasi((WASMModuleInstanceCommon*)module_inst,
+                                    module->wasi_args.dir_list,
+                                    module->wasi_args.dir_count,
+                                    module->wasi_args.map_dir_list,
+                                    module->wasi_args.map_dir_count,
+                                    module->wasi_args.env,
+                                    module->wasi_args.env_count,
+                                    module->wasi_args.argv,
+                                    module->wasi_args.argc,
+                                    error_buf, error_buf_size)) {
             goto fail;
         }
     }


### PR DESCRIPTION
Remove check for heap_size==0 when creating wasi ctx, as the related data structures are allocated from global heap instead of app heap now, so it also works when app heap isn't created.
Also add v128 type for Windows so as to fix wamrc compilation error in Windows platform.

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>