### PR TITLE
Call asc app exported new/pin/unpin APIs to align with its latest compiler (#577)

### DIFF
--- a/assembly-script/package.json
+++ b/assembly-script/package.json
@@ -5,16 +5,16 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:request_handler": "asc samples/request_handler.ts -b build/request_handler.wasm -t build/request_handler.wat --sourceMap --optimize --use abort=",
-    "build:request_sender": "asc samples/request_sender.ts -b build/request_sender.wasm -t build/request_sender.wat --sourceMap --optimize --use abort=",
-    "build:timer": "asc samples/timer.ts -b build/timer.wasm -t build/timer.wat --sourceMap --optimize --use abort=",
-    "build:publisher": "asc samples/event_publisher.ts -b build/event_publisher.wasm -t build/event_publisher.wat --sourceMap --optimize --use abort=",
-    "build:subscriber": "asc samples/event_subscriber.ts -b build/event_subscriber.wasm -t build/event_subscriber.wat --sourceMap --optimize --use abort=",
+    "build:request_handler": "asc samples/request_handler.ts -b build/request_handler.wasm -t build/request_handler.wat --sourceMap --optimize --exportRuntime --use abort=",
+    "build:request_sender": "asc samples/request_sender.ts -b build/request_sender.wasm -t build/request_sender.wat --sourceMap --optimize --exportRuntime --use abort=",
+    "build:timer": "asc samples/timer.ts -b build/timer.wasm -t build/timer.wat --sourceMap --optimize --exportRuntime --use abort=",
+    "build:publisher": "asc samples/event_publisher.ts -b build/event_publisher.wasm -t build/event_publisher.wat --sourceMap --optimize --exportRuntime --use abort=",
+    "build:subscriber": "asc samples/event_subscriber.ts -b build/event_subscriber.wasm -t build/event_subscriber.wat --sourceMap --optimize --exportRuntime --use abort=",
     "build:all": "npm run build:request_handler; npm run build:request_sender; npm run build:timer; npm run build:subscriber; npm run build:publisher"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "assemblyscript": "^0.17.4"
+    "assemblyscript": "^0.18.15"
   }
 }

--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -1960,7 +1960,8 @@ load_from_sections(AOTModule *module, AOTSection *sections,
                     export_tmp = module->exports;
                     for (j = 0; j < module->export_count; j++, export_tmp++) {
                         if ((export_tmp->kind == EXPORT_KIND_FUNC)
-                            && (!strcmp(export_tmp->name, "__retain"))) {
+                            && (!strcmp(export_tmp->name, "__retain")
+                                || !strcmp(export_tmp->name, "__pin"))) {
                             func_index = export_tmp->index
                                             - module->import_func_count;
                             func_type_index =
@@ -1988,7 +1989,8 @@ load_from_sections(AOTModule *module, AOTSection *sections,
                 }
             }
             else if ((!strcmp(exports[i].name, "free"))
-                     || (!strcmp(exports[i].name, "__release"))) {
+                     || (!strcmp(exports[i].name, "__release"))
+                     || (!strcmp(exports[i].name, "__unpin"))) {
                 func_index = exports[i].index - module->import_func_count;
                 func_type_index = module->func_type_indexes[func_index];
                 func_type = module->func_types[func_type_index];

--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1502,6 +1502,8 @@ aot_module_malloc(AOTModuleInstance *module_inst, uint32 size,
             malloc_func_sig = "(ii)i";
             retain_func =
                 aot_lookup_function(module_inst, "__retain", "(i)i");
+            if (!retain_func)
+                retain_func = aot_lookup_function(module_inst, "__pin", "(i)i");
             bh_assert(retain_func);
         }
         else {
@@ -1573,6 +1575,8 @@ aot_module_free(AOTModuleInstance *module_inst, uint32 ptr)
             }
             free_func =
                 aot_lookup_function(module_inst, free_func_name, "(i)i");
+            if (!free_func && module->retain_func_index != (uint32)-1)
+                free_func = aot_lookup_function(module_inst, "__unpin", "(i)i");
 
             bh_assert(free_func);
             execute_free_function(module_inst, free_func, ptr);

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2768,7 +2768,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
             }
             else if (!strcmp(export->name, "__new")
                      && export->index >= module->import_function_count) {
-                /* __new && __retain for AssemblyScript */
+                /* __new && __pin for AssemblyScript */
                 func_index = export->index - module->import_function_count;
                 func_type = module->functions[func_index]->func_type;
                 if (func_type->param_count == 2
@@ -2789,7 +2789,8 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     export_tmp = module->exports;
                     for (j = 0; j < module->export_count; j++, export_tmp++) {
                         if ((export_tmp->kind == EXPORT_KIND_FUNC)
-                            && (!strcmp(export_tmp->name, "__retain"))
+                            && (!strcmp(export_tmp->name, "__retain")
+                                || (!strcmp(export_tmp->name, "__pin")))
                             && (export_tmp->index
                                 >= module->import_function_count)) {
                             func_index = export_tmp->index
@@ -2818,7 +2819,8 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                 }
             }
             else if (((!strcmp(export->name, "free"))
-                      || (!strcmp(export->name, "__release")))
+                      || (!strcmp(export->name, "__release"))
+                      || (!strcmp(export->name, "__unpin")))
                      && export->index >= module->import_function_count) {
                 func_index = export->index - module->import_function_count;
                 func_type = module->functions[func_index]->func_type;

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -1664,7 +1664,7 @@ load_from_sections(WASMModule *module, WASMSection *sections,
             }
             else if (!strcmp(export->name, "__new")
                      && export->index >= module->import_function_count) {
-                /* __new && __retain for AssemblyScript */
+                /* __new && __pin for AssemblyScript */
                 func_index = export->index - module->import_function_count;
                 func_type = module->functions[func_index]->func_type;
                 if (func_type->param_count == 2
@@ -1685,7 +1685,8 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                     export_tmp = module->exports;
                     for (j = 0; j < module->export_count; j++, export_tmp++) {
                         if ((export_tmp->kind == EXPORT_KIND_FUNC)
-                            && (!strcmp(export_tmp->name, "__retain"))
+                            && (!strcmp(export_tmp->name, "__retain")
+                                || !strcmp(export_tmp->name, "__pin"))
                             && (export_tmp->index
                                 >= module->import_function_count)) {
                             func_index = export_tmp->index
@@ -1714,7 +1715,8 @@ load_from_sections(WASMModule *module, WASMSection *sections,
                 }
             }
             else if (((!strcmp(export->name, "free"))
-                      || (!strcmp(export->name, "__release")))
+                      || (!strcmp(export->name, "__release"))
+                      || (!strcmp(export->name, "__unpin")))
                      && export->index >= module->import_function_count) {
                 func_index = export->index - module->import_function_count;
                 func_type = module->functions[func_index]->func_type;


### PR DESCRIPTION
AssemblyScript's latest compiler 0.18 exports  __new__/__pin__/unpin APIs to allocate/retain/free memory instead of __new/__retain/__release APIs in older version, we lookup functions of both version to make it compatible for both version.