### PR TITLE
Fix sample littlevgl/gui build issues on zephyr platform (#588)

### DIFF
--- a/core/shared/platform/zephyr/platform_internal.h
+++ b/core/shared/platform/zephyr/platform_internal.h
@@ -9,7 +9,12 @@
 #include <autoconf.h>
 #include <zephyr.h>
 #include <kernel.h>
+#include <version.h>
+#if KERNEL_VERSION_NUMBER >= 0x020200 /* version 2.2.0 */
 #include <sys/printk.h>
+#else
+#include <misc/printk.h>
+#endif
 #include <inttypes.h>
 #include <stdarg.h>
 #include <ctype.h>
@@ -53,7 +58,13 @@ typedef struct korp_cond {
     os_thread_wait_list thread_wait_list;
 } korp_cond;
 
-#define os_printf printf
+#ifndef Z_TIMEOUT_MS
+#define Z_TIMEOUT_MS(ms) ms
+#endif
+
+void abort(void);
+size_t strspn(const char *s, const char *accept);
+size_t strcspn(const char *s, const char *reject);
 
 /* math functions which are not provided by os */
 double sqrt(double x);

--- a/core/shared/platform/zephyr/zephyr_platform.c
+++ b/core/shared/platform/zephyr/zephyr_platform.c
@@ -101,7 +101,6 @@ char_out(int c, void *ctx)
     out_ctx->count++;
     return _stdout_hook_iwasm(c);
 }
-#endif
 
 int
 os_vprintf(const char *fmt, va_list ap)
@@ -115,6 +114,59 @@ os_vprintf(const char *fmt, va_list ap)
     return 0;
 #endif
 }
+#endif
+
+int
+os_printf(const char *format, ...)
+{
+    int ret = 0;
+    va_list ap;
+
+    va_start(ap, format);
+#ifndef BH_VPRINTF
+    ret += vprintf(format, ap);
+#else
+    ret += BH_VPRINTF(format, ap);
+#endif
+    va_end(ap);
+
+    return ret;
+}
+
+int
+os_vprintf(const char *format, va_list ap)
+{
+#ifndef BH_VPRINTF
+    return vprintf(format, ap);
+#else
+    return BH_VPRINTF(format, ap);
+#endif
+}
+
+#if KERNEL_VERSION_NUMBER <= 0x020400 /* version 2.4.0 */
+void
+abort(void)
+{
+    int i = 0;
+    os_printf("%d\n", 1 / i);
+}
+#endif
+
+#if KERNEL_VERSION_NUMBER <= 0x010E01 /* version 1.14.1 */
+size_t
+strspn(const char *s, const char *accept)
+{
+    os_printf("## unimplemented function %s called", __FUNCTION__);
+    return 0;
+}
+
+size_t
+strcspn(const char *s, const char *reject)
+{
+    os_printf("## unimplemented function %s called", __FUNCTION__);
+    return 0;
+}
+#endif
 
 void *
 os_mmap(void *hint, size_t size, int prot, int flags)

--- a/core/shared/platform/zephyr/zephyr_thread.c
+++ b/core/shared/platform/zephyr/zephyr_thread.c
@@ -353,7 +353,12 @@ int os_mutex_lock(korp_mutex *mutex)
 
 int os_mutex_unlock(korp_mutex *mutex)
 {
+#if KERNEL_VERSION_NUMBER >= 0x020200 /* version 2.2.0 */
     return k_mutex_unlock(mutex);
+#else
+    k_mutex_unlock(mutex);
+    return 0;
+#endif
 }
 
 int os_cond_init(korp_cond *cond)

--- a/product-mini/platforms/zephyr/simple/build_and_run.sh
+++ b/product-mini/platforms/zephyr/simple/build_and_run.sh
@@ -5,22 +5,22 @@
 
 X86_TARGET="x86"
 STM32_TARGET="stm32"
-QEMU_CORTEX_A53="qemu_cortex_a53"
-XTENSA_QEMU_TARGET="xtensa-qemu"
 ESP32_TARGET="esp32"
+QEMU_CORTEX_A53="qemu_cortex_a53"
+QEMU_XTENSA_TARGET="qemu_xtensa"
 QEMU_RISCV64_TARGET="qemu_riscv64"
 QEMU_RISCV32_TARGET="qemu_riscv32"
 
 usage ()
 {
         echo "USAGE:"
-        echo "$0 $X86_TARGET|$STM32_TARGET|$QEMU_CORTEX_A53|$XTENSA_QEMU_TARGET|$ESP32_TARGET|$QEMU_RISCV64_TARGET|$QEMU_RISCV32_TARGET"
+        echo "$0 $X86_TARGET|$STM32_TARGET|$ESP32_TARGET|$QEMU_CORTEX_A53|$QEMU_XTENSA_TARGET|$QEMU_RISCV64_TARGET|$QEMU_RISCV32_TARGET"
         echo "Example:"
         echo "        $0 $X86_TARGET"
         echo "        $0 $STM32_TARGET"
-        echo "        $0 $QEMU_CORTEX_A53"
-        echo "        $0 $XTENSA_QEMU_TARGET"
         echo "        $0 $ESP32_TARGET"
+        echo "        $0 $QEMU_CORTEX_A53"
+        echo "        $0 $QEMU_XTENSA_TARGET"
         echo "        $0 $QEMU_RISCV64_TARGET"
         echo "        $0 $QEMU_RISCV32_TARGET"
         exit 1
@@ -47,13 +47,6 @@ case $TARGET in
                            -DWAMR_BUILD_TARGET=THUMBV7
                 west flash
                 ;;
-        $XTENSA_QEMU_TARGET)
-                west build -b qemu_xtensa \
-                           . -p always -- \
-                           -DCONF_FILE=prj_qemu_xtensa.conf \
-                           -DWAMR_BUILD_TARGET=XTENSA
-                west build -t run
-                ;;
         $ESP32_TARGET)
                 # suppose you have set environment variable ESP_IDF_PATH
                 west build -b esp32 \
@@ -64,6 +57,13 @@ case $TARGET in
                 # suppose the serial port is /dev/ttyUSB1 and you should change to
                 # the real name accordingly
                 west flash --esp-device /dev/ttyUSB1
+                ;;
+        $QEMU_XTENSA_TARGET)
+                west build -b qemu_xtensa \
+                           . -p always -- \
+                           -DCONF_FILE=prj_qemu_xtensa.conf \
+                           -DWAMR_BUILD_TARGET=XTENSA
+                west build -t run
                 ;;
         $QEMU_CORTEX_A53)
                 west build -b qemu_cortex_a53 \

--- a/samples/gui/README.md
+++ b/samples/gui/README.md
@@ -1,16 +1,14 @@
 "gui" sample introduction
 ==============
-This sample demonstrates that a graphic user interface application in WebAssembly programming with WAMR graphic library(WGL)  which is part of WAMR app-framework. 
+This sample demonstrates that a graphic user interface application in WebAssembly programming with WAMR graphic library(WGL)  which is part of WAMR app-framework.
 
 Compared with the [littlevgl](../littlevgl) sample, WGL compiles LittlevGL source code into the WAMR runtime and defines a set of wrapper API's for exporting to Webassembly application.
 
-
 Below picture shows the WASM application is running on an STM board with an LCD touch panel.
-
 
 ![WAMR UI SAMPLE](../../doc/pics/vgl_demo2.png "WAMR UI DEMO")
 
- When users click the blue button, the WASM application increases the counter, and the latest counter value is displayed on the top banner of the touch panel. The number on top will plus one each second, and the number on the bottom will plus one when clicked.
+ When user clicks the blue button, the WASM application increases the counter, and the latest counter value is displayed on the top banner of the touch panel. The number on top will plus one each second, and the number on the bottom will plus one when clicked.
 
 # Test on Linux
 
@@ -18,61 +16,81 @@ Install required SDK and libraries
 --------------
 - 32 bit SDL(simple directmedia layer) (Note: only necessary when `WAMR_BUILD_TARGET` is set to `X86_32` when building WAMR runtime)
 Use apt-get:
-    `sudo apt-get install libsdl2-dev:i386`
+  ```bash
+  sudo apt-get install libsdl2-dev:i386
+  ```
 Or download source from www.libsdl.org:
-```
-./configure C_FLAGS=-m32 CXX_FLAGS=-m32 LD_FLAGS=-m32
-make
-sudo make install
-```
+  ```bash
+  ./configure C_FLAGS=-m32 CXX_FLAGS=-m32 LD_FLAGS=-m32
+  make
+  sudo make install
+  ```
 - 64 bit SDL(simple directmedia layer) (Note: only necessary when `WAMR_BUILD_TARGET` is set to `X86_64` when building WAMR runtime)
 Use apt-get:
-    `sudo apt-get install libsdl2-dev`
-Or download source from www.libsdl.org:
-```
-./configure
-make
-sudo make install
-```
+
+  ```bash
+  sudo apt-get install libsdl2-dev
+  ```
+  Or download source from www.libsdl.org:
+  ```bash
+  ./configure
+  make
+  sudo make install
+  ```
 
 Build and Run
 --------------
 
-- Build</br>
-`./build.sh`</br>
+- Build
+  ```bash
+  ./build.sh
+  ```
     All binaries are in "out", which contains "host_tool", "ui_decrease.wasm", "ui_increase.wasm" and "wasm_runtime_wgl".
 
-- Run WASM VM Linux applicaton & install WASM APP</br>
- First start wasm_runtime_wgl in server mode.</br>
-`./wasm_runtime_wgl -s`</br>
- Then install wasm APP use host tool.</br>
-`./host_tool -i inc -f ui_increase.wasm`</br>
-`./host_tool -i dec -f ui_decrease.wasm`</br>
-
-
+- Run WASM VM Linux applicaton & install WASM APP
+ First start wasm_runtime_wgl in server mode.
+  ```bash
+  ./wasm_runtime_wgl -s
+  ```
+ Then install wasm APP by using host tool.
+  ```bash
+  ./host_tool -i inc -f ui_increase.wasm
+  # or
+  ./host_tool -i dec -f ui_decrease.wasm
+  ```
 
 Test on Zephyr
 ================================
 
 We can use a STM32 NUCLEO_F767ZI  board with ILI9341 display and XPT2046 touch screen to run the test. Then use host_tool to remotely install wasm app into STM32.
-- Build WASM VM into Zephyr system</br>
- a. clone zephyr source code</br>
-Refer to Zephyr getting started.</br>
-https://docs.zephyrproject.org/latest/getting_started/index.html</br>
-`west init zephyrproject`</br>
-`cd zephyrproject`</br>
-`west update`</br>
- b. copy samples</br>
-    `cd zephyr/samples/`</br>
-    `cp -a <wamr_root>samples/gui/wasm-runtime-wgl wasm-runtime-wgl`</br>
-    `cd wasm-runtime-wgl/zephyr_build`</br>
- c. create a link to wamr root dir</br>
-   ` ln -s <wamr_root> wamr`</br>
- d. build source code</br>
-    `mkdir build && cd build`</br>
-    `source ../../../../zephyr-env.sh`</br>
-    `cmake -GNinja -DBOARD=nucleo_f767zi ..`</br>
-   ` ninja flash`</br>
+- Build WASM VM into Zephyr system
+ a. clone zephyr source code
+Refer to  [Zephyr getting started](https://docs.zephyrproject.org/latest/getting_started/index.html).
+
+  ```bash
+  west init zephyrproject
+  cd zephyrproject/zephyr
+  git checkout zephyr-v2.3.0
+  cd ..
+  west update
+  ```
+ b. copy samples
+  ```bash
+  cd zephyr/samples
+  cp -a <wamr_root>samples/gui/wasm-runtime-wgl wasm-runtime-wgl
+  cd wasm-runtime-wgl/zephyr_build
+  ```
+ c. create a link to wamr root dir
+  ```bash
+  ln -s <wamr_root> wamr
+  ```
+ d. build source code
+  ```bash
+  mkdir build && cd build
+  source ../../../../zephyr-env.sh
+  cmake -GNinja -DBOARD=nucleo_f767zi ..
+  ninja flash
+  ```
 
 - Hardware Connections
 
@@ -102,16 +120,17 @@ https://docs.zephyrproject.org/latest/getting_started/index.html</br>
 +-------------------+-+------------------+
 ```
 
-
-- Install WASM application to Zephyr using host_tool</br>
-First, connect PC and STM32 with UART. Then install to use host_tool.</br>
-`./host_tool -D /dev/ttyUSBXXX -i inc -f ui_increase.wasm`
+- Install WASM application to Zephyr using host_tool
+First, connect PC and STM32 with UART. Then install to use host_tool.
+  ```bash
+  ./host_tool -D /dev/ttyUSBXXX -i inc -f ui_increase.wasm
+  ```
 
 - Install AOT version WASM application
-`wamrc --target=thumbv7 --target-abi=eabi --cpu=cortex-m7 -o ui_app.aot ui_increase.wasm`
-`./host_tool -D /dev/ttyUSBXXX -i inc -f ui_app.aot`
-
-
+  ```bash
+  wamrc --target=thumbv7 --target-abi=eabi --cpu=cortex-m7 -o ui_app.aot ui_increase.wasm
+  ./host_tool -D /dev/ttyUSBXXX -i inc -f ui_app.aot
+  ```
 
 The graphic user interface demo photo:
 

--- a/samples/littlevgl/README.md
+++ b/samples/littlevgl/README.md
@@ -4,7 +4,7 @@ This sample demonstrates that a graphic user interface application in WebAssembl
 
 In this sample, the whole LittlevGL v5.3 source code is built into the WebAssembly code with the user application. The platform interfaces defined by LittlevGL is implemented in the runtime and registered for WASM application through calling wasm_runtime_full_init().
 
-```
+```C
 static NativeSymbol native_symbols[] = {
     EXPORT_WASM_API_WITH_SIG(display_input_read, "(*)i"),
     EXPORT_WASM_API_WITH_SIG(display_flush, "(iiii*)"),
@@ -18,14 +18,14 @@ static NativeSymbol native_symbols[] = {
 The runtime component supports building target for Linux and Zephyr/STM Nucleo board. The beauty of this sample is the WebAssembly application can have identical display and behavior when running from both runtime environments. That implies we can do majority of application validation from desktop environment as long as two runtime distributions support the same set of application interface.
 
 
-Below pictures show the WASM application is running on an STM board with an LCD touch panel. 
+Below pictures show the WASM application is running on an STM board with an LCD touch panel.
 
 ![WAMR UI SAMPLE](../../doc/pics/vgl_demo2.png "WAMR UI DEMO STM32")
 
 ![WAMR UI SAMPLE](../../doc/pics/vgl_demo_linux.png "WAMR UI DEMO LINUX")
 
 
-The number on top will plus one each second, and the number on the bottom will plus one when clicked. When users click the blue button, the WASM application increases the counter, and the latest counter value is displayed on the top banner of the touch panel. 
+The number on top will plus one each second, and the number on the bottom will plus one when clicked. When users click the blue button, the WASM application increases the counter, and the latest counter value is displayed on the top banner of the touch panel.
 
 The sample also provides the native Linux version of application without the runtime under folder "vgl-native-ui-app". It can help to check differences between the implementations in native and WebAssembly.
 
@@ -36,57 +36,67 @@ Install required SDK and libraries
 --------------
 - 32 bit SDL(simple directmedia layer) (Note: only necessary when `WAMR_BUILD_TARGET` is set to `X86_32` when building WAMR runtime)
 Use apt-get:
-    `sudo apt-get install libsdl2-dev:i386`
+  ```bash
+  sudo apt-get install libsdl2-dev:i386
+  ```
 Or download source from www.libsdl.org:
-```
-./configure C_FLAGS=-m32 CXX_FLAGS=-m32 LD_FLAGS=-m32
-make
-sudo make install
-```
+  ```bash
+  ./configure C_FLAGS=-m32 CXX_FLAGS=-m32 LD_FLAGS=-m32
+  make
+  sudo make install
+  ```
 - 64 bit SDL(simple directmedia layer) (Note: only necessary when `WAMR_BUILD_TARGET` is set to `X86_64` when building WAMR runtime)
 Use apt-get:
-    `sudo apt-get install libsdl2-dev`
+  ```bash
+  sudo apt-get install libsdl2-dev
+  ```
 Or download source from www.libsdl.org:
-```
-./configure
-make
-sudo make install
-```
-
+  ```bash
+  ./configure
+  make
+  sudo make install
+  ```
 
 Build and Run
 --------------
 
-- Build</br>
-`./build.sh`</br>
+- Build
+  ```bash
+  ./build.sh
+  ```
     All binaries are in "out", which contains "host_tool", "vgl_native_ui_app", "ui_app.wasm" "ui_app_no_wasi.wasm "and "vgl_wasm_runtime".
-- Run the native Linux build of the lvgl sample (no wasm) </br>
-`./vgl_native_ui_app`</br>
+- Run the native Linux build of the lvgl sample (no wasm)
+  ```bash
+  ./vgl_native_ui_app
+  ```
 
-- Run WASM VM Linux applicaton & install WASM APP</br>
- First start vgl_wasm_runtime in server mode.</br>
-`./vgl_wasm_runtime -s`</br>
- Then install and uninstall wasm APPs by using host tool.</br>
-`./host_tool -i ui_wasi -f ui_app_wasi.wasm`</br>
-`./host_tool -q`</br>
-`./host_tool -u ui_wasi`</br>
-`./host_tool -i ui_no_wasi -f ui_app_builtin_libc.wasm`</br>
-`./host_tool -q`</br>
-`./host_tool -u ui_no_wasi`</br>
-
-
+- Run WASM VM Linux applicaton & install WASM APP
+ First start vgl_wasm_runtime in server mode.
+  ```bash
+  ./vgl_wasm_runtime -s
+  ```
+ Then install and uninstall wasm APPs by using host tool.
+  ```bash
+  ./host_tool -i ui_wasi -f ui_app_wasi.wasm
+  ./host_tool -q
+  ./host_tool -u ui_wasi
+  ./host_tool -i ui_no_wasi -f ui_app_builtin_libc.wasm
+  ./host_tool -q
+  ./host_tool -u ui_no_wasi
+  ```
 
 Test on Zephyr
 ================================
 We can use a STM32 NUCLEO_F767ZI  board with ILI9341 display and XPT2046 touch screen to run the test. Then use host_tool to remotely install wasm app into STM32.
 - Build WASM VM into Zephyr system
   a. clone zephyr source code
-  Refer to Zephyr getting started.
-  https://docs.zephyrproject.org/latest/getting_started/index.html
+  Refer to [Zephyr getting started](https://docs.zephyrproject.org/latest/getting_started/index.html).
 
   ```bash
   west init zephyrproject
-  cd zephyrproject
+  cd zephyrproject/zephyr
+  git checkout zephyr-v2.3.0
+  cd ..
   west update
   ```
 
@@ -101,24 +111,24 @@ We can use a STM32 NUCLEO_F767ZI  board with ILI9341 display and XPT2046 touch s
   ln -s <wamr_root> wamr
   ```
 
-  d. build source code
+d. build source code
   Since ui_app incorporated LittlevGL source code, so it needs more RAM on the device to install the application.  It is recommended that RAM SIZE not less than 380KB. In our test use nucleo_f767zi, which is supported by Zephyr. Since the littlevgl wasm app is quite big (~100KB in wasm format and ~200KB in AOT format ), there isn't enough SRAM to build interpreter and AOT together. You can only choose one of them:
 
   - Interpreter
-    ``` Bash
-    mkdir build && cd build
-    source ../../../../zephyr-env.sh
-    cmake -GNinja -DBOARD=nucleo_f767zi -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_AOT=0 ..
-    ninja flash
-    ```
+  ```bash
+  mkdir build && cd build
+  source ../../../../zephyr-env.sh
+  cmake -GNinja -DBOARD=nucleo_f767zi -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_AOT=0 ..
+  ninja flash
+  ```
 
   - AOT
-  ``` Bash
-    mkdir build && cd build
-    source ../../../../zephyr-env.sh
-    cmake -GNinja -DBOARD=nucleo_f767zi -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_AOT=1 ..
-    ninja flash
-    ```
+  ```bash
+  mkdir build && cd build
+  source ../../../../zephyr-env.sh
+  cmake -GNinja -DBOARD=nucleo_f767zi -DWAMR_BUILD_INTERP=0 -DWAMR_BUILD_AOT=1 ..
+  ninja flash
+  ```
 
 - Hardware Connections
 
@@ -148,12 +158,16 @@ We can use a STM32 NUCLEO_F767ZI  board with ILI9341 display and XPT2046 touch s
 +-------------------+-+------------------+
 ```
 
-
-- Install WASM application to Zephyr using host_tool</br>
-First, connect PC and STM32 with UART. Then install to use host_tool.</br>
-`./host_tool -D /dev/ttyUSBXXX -i ui_app -f ui_app_builtin_libc.wasm`
+- Install WASM application to Zephyr using host_tool
+First, connect PC and STM32 with UART. Then install to use host_tool.
+  ```bash
+  ./host_tool -D /dev/ttyUSBXXX -i ui_app -f ui_app_builtin_libc.wasm
+  ```
 **Note**: WASI is unavailable on zephyr currently, so you have to use the ui_app_builtin_libc.wasm which doesn't depend on WASI.
 
 - Install AOT version WASM application
-`wamrc --target=thumbv7 --target-abi=eabi --cpu=cortex-m7 -o ui_app_no_wasi.aot ui_app_builtin_libc.wasm`
-`./host_tool -D /dev/ttyUSBXXX -i ui_app -f ui_app_no_wasi.aot`
+  ```bash
+  wamrc --target=thumbv7 --target-abi=eabi --cpu=cortex-m7 -o ui_app_no_wasi.aot ui_app_builtin_libc.wasm
+  ./host_tool -D /dev/ttyUSBXXX -i ui_app -f ui_app_no_wasi.aot
+  ```
+

--- a/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.c
+++ b/samples/littlevgl/vgl-wasm-runtime/src/platform/zephyr/display_ili9340.c
@@ -76,7 +76,7 @@ ili9340_init()
 
     data->command_data_gpio = device_get_binding(
                                 DT_ILITEK_ILI9340_0_CMD_DATA_GPIOS_CONTROLLER);
-    if (data->command_data_gpio == NULL) {    
+    if (data->command_data_gpio == NULL) {
         return -EPERM;
     }
 
@@ -175,7 +175,7 @@ ili9340_get_framebuffer(const struct device *dev)
 static int
 ili9340_display_blanking_off(const struct device *dev)
 {
-    struct ili9340_data *data = (struct ili9340_data *)dev->data;
+    struct ili9340_data *data = (struct ili9340_data *)dev->driver_data;
 
     LOG_DBG("Turning display blanking off\n");
     ili9340_transmit(data, ILI9340_CMD_DISPLAY_ON, NULL, 0);
@@ -185,7 +185,7 @@ ili9340_display_blanking_off(const struct device *dev)
 static int
 ili9340_display_blanking_on(const struct device *dev)
 {
-    struct ili9340_data *data = (struct ili9340_data *)dev->data;
+    struct ili9340_data *data = (struct ili9340_data *)dev->driver_data;
 
     LOG_DBG("Turning display blanking on\n");
     ili9340_transmit(data, ILI9340_CMD_DISPLAY_OFF, NULL, 0);

--- a/test-tools/host-tool/src/main.c
+++ b/test-tools/host-tool/src/main.c
@@ -113,7 +113,7 @@ static int send_request(request_t *request, uint16_t msg_type)
     if ((req_p = pack_request(request, &req_size)) == NULL)
         return -1;
 
-    /* leanding bytes */
+    /* leading bytes */
     if (!host_tool_send_data(g_conn_fd, leading, sizeof(leading)))
         goto ret;
 
@@ -648,8 +648,8 @@ static bool parse_args(int argc, char *argv[], operation *op)
  *               REPLY_TYPE_EVENT: event(request)
  *               REPLY_TYPE_RESPONSE: response
  */
-static int preocess_reply_data(const char *buf, int len,
-        imrt_link_recv_context_t *ctx)
+static int process_reply_data(const char *buf, int len,
+                              imrt_link_recv_context_t *ctx)
 {
     int result = -1;
     const char *pos = buf;
@@ -849,7 +849,7 @@ int main(int argc, char *argv[])
                     continue;
                 }
 
-                reply_type = preocess_reply_data((char *) buffer, n, &recv_ctx);
+                reply_type = process_reply_data((char *) buffer, n, &recv_ctx);
 
                 if (reply_type == REPLY_TYPE_RESPONSE) {
                     response_t response[1] = { 0 };

--- a/test-tools/host-tool/src/transport.c
+++ b/test-tools/host-tool/src/transport.c
@@ -233,11 +233,6 @@ int on_imrt_link_byte_arrive(unsigned char ch, imrt_link_recv_context_t *ctx)
                 return 0;
             }
 
-            if (ctx->message.payload_size > 1024 * 1024) {
-                SET_RECV_PHASE(ctx, Phase_Non_Start);
-                return -1;
-            }
-
             ctx->message.payload = (char *) malloc(ctx->message.payload_size);
             SET_RECV_PHASE(ctx, Phase_Payload);
         }


### PR DESCRIPTION
Fix sample littlevgl/guil build issues on zephyr platform, modify code of zephyr platform by adding some macros to control some apis to fit different zephyr version, and align to zephyr-v2.3.0 for sample littlevgl/gui as the latest zephyr version (>=v2.4.0) requires that the thread stack for the thread to create must be defined by macro but not allocating stack memory dynamically.

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>