### PR TITLE
Enable Android libc wasi support. (#590)

### DIFF
--- a/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
+++ b/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/ssp_config.h
@@ -14,7 +14,7 @@
 
 #include <stdlib.h>
 
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || (defined(ANDROID) && __ANDROID_API__ < 28)
 #define CONFIG_HAS_ARC4RANDOM_BUF 1
 #else
 #define CONFIG_HAS_ARC4RANDOM_BUF 0

--- a/core/shared/platform/android/platform_init.c
+++ b/core/shared/platform/android/platform_init.c
@@ -5,6 +5,12 @@
 
 #include "platform_api_vmcore.h"
 #include "platform_api_extension.h"
+
+#define API_NOT_SUPPORT_ERROR(API, VERSION)                                   \
+    __android_log_print(ANDROID_LOG_ERROR, "wasm_runtime::",                  \
+                        "%s() is only supported when __ANDROID_API__ >= %s.", \
+                        #API, #VERSION);
+
 int
 bh_platform_init()
 {
@@ -33,3 +39,78 @@ int os_vprintf(const char *fmt, va_list ap)
     return __android_log_vprint(ANDROID_LOG_INFO, "wasm_runtime::", fmt, ap);
 }
 
+#if __ANDROID_API__ < 19
+
+int futimens(int __dir_fd, const struct timespec __times[2])
+{
+    API_NOT_SUPPORT_ERROR(futimens, 19);
+    return -1;
+}
+
+#endif
+
+#if __ANDROID_API__ < 21
+
+int posix_fallocate(int __fd, off_t __offset, off_t __length)
+{
+    API_NOT_SUPPORT_ERROR(posix_fallocate, 21);
+    return -1;
+}
+
+int posix_fadvise(int fd, off_t offset, off_t len, int advice)
+{
+    API_NOT_SUPPORT_ERROR(posix_fadvise, 21);
+    return -1;
+}
+
+int linkat(int __old_dir_fd, const char *__old_path,
+           int __new_dir_fd, const char *__new_path, int __flags)
+{
+    API_NOT_SUPPORT_ERROR(linkat, 21);
+    return -1;
+}
+
+int symlinkat(const char *__old_path, int __new_dir_fd, const char *__new_path)
+{
+    API_NOT_SUPPORT_ERROR(symlinkat, 21);
+    return -1;
+}
+
+ssize_t readlinkat(int __dir_fd, const char *__path, char *__buf, size_t __buf_size)
+{
+    API_NOT_SUPPORT_ERROR(readlinkat, 21);
+    return -1;
+}
+
+#endif
+
+#if __ANDROID_API__ < 23
+
+long telldir(DIR *__dir)
+{
+    API_NOT_SUPPORT_ERROR(telldir, 23);
+    return -1;
+}
+
+void seekdir(DIR *__dir, long __location)
+{
+    API_NOT_SUPPORT_ERROR(seekdir, 23);
+}
+
+#endif
+
+#if __ANDROID_API__ < 24
+
+ssize_t preadv(int __fd, const struct iovec *__iov, int __count, off_t __offset)
+{
+    API_NOT_SUPPORT_ERROR(preadv, 24);
+    return -1;
+}
+
+ssize_t pwritev(int __fd, const struct iovec *__iov, int __count, off_t __offset)
+{
+    API_NOT_SUPPORT_ERROR(pwritev, 24);
+    return -1;
+}
+
+#endif

--- a/core/shared/platform/android/platform_internal.h
+++ b/core/shared/platform/android/platform_internal.h
@@ -87,6 +87,45 @@ void os_sigreturn();
 #endif /* end of BUILD_TARGET_X86_64/AMD_64/AARCH64 */
 #endif /* end of WASM_DISABLE_HW_BOUND_CHECK */
 
+typedef long int __syscall_slong_t;
+
+#if __ANDROID_API__ < 19
+
+int futimens(int __dir_fd, const struct timespec __times[2]);
+
+#endif
+
+#if __ANDROID_API__ < 21
+
+int posix_fallocate(int __fd, off_t __offset, off_t __length);
+
+int posix_fadvise(int fd, off_t offset, off_t len, int advice);
+
+int linkat(int __old_dir_fd, const char *__old_path,
+           int __new_dir_fd, const char *__new_path, int __flags);
+
+int symlinkat(const char *__old_path, int __new_dir_fd, const char *__new_path);
+
+ssize_t readlinkat(int __dir_fd, const char *__path, char *__buf, size_t __buf_size);
+
+#endif
+
+#if __ANDROID_API__ < 23
+
+long telldir(DIR *__dir);
+
+void seekdir(DIR *__dir, long __location);
+
+#endif
+
+#if __ANDROID_API__ < 24
+
+ssize_t preadv(int __fd, const struct iovec *__iov, int __count, off_t __offset);
+
+ssize_t pwritev(int __fd, const struct iovec *__iov, int __count, off_t __offset);
+
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/product-mini/platforms/android/CMakeLists.txt
+++ b/product-mini/platforms/android/CMakeLists.txt
@@ -11,6 +11,9 @@ set (ANDROID_NDK $ENV{ANDROID_NDK_HOME})
 set (ANDROID_SDK $ENV{ANDROID_SDK_HOME})
 set (ANDROID_ABI "x86")
 set (ANDROID_LD lld)
+if (NOT DEFINED ANDROID_PLATFORM)
+  set (ANDROID_PLATFORM 24)
+endif ()
 
 project (iwasm)
 
@@ -20,7 +23,7 @@ set (WAMR_BUILD_TYPE          Release)
 set (WAMR_BUILD_INTERP        1)
 set (WAMR_BUILD_AOT           0)
 set (WAMR_BUILD_LIBC_BUILTIN  1)
-set (WAMR_BUILD_LIBC_WASI     0)
+set (WAMR_BUILD_LIBC_WASI     1)
 
 # Reset default linker flags
 set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")


### PR DESCRIPTION
Some libc APIs required by wasi native lib are missing in some Android API versions, only when the version >= 24, all APIs are supported. Add the missing APIs in android platform layer, leave them empty, report error and return failed if they are called. Also update CMakeLists.txt to enable libc wasi by default.

Co-authored-by: Wenyong Huang <wenyong.huang@intel.com>