### PR TITLE
sgx: fix the build warning (#653)

### DIFF
--- a/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
+++ b/product-mini/platforms/linux-sgx/enclave-sample/App/App.cpp
@@ -97,11 +97,12 @@ enclave_init(sgx_enclave_id_t *p_eid)
      */
     /* try to get the token saved in $HOME */
     home_dir = getpwuid(getuid())->pw_dir;
+    size_t home_dir_len = home_dir ? strlen(home_dir) : 0;
 
     if (home_dir != NULL &&
-        (strlen(home_dir) + strlen("/") + sizeof(TOKEN_FILENAME) + 1) <= MAX_PATH) {
+        home_dir_len <= MAX_PATH - 1 - sizeof(TOKEN_FILENAME) - strlen("/")) {
         /* compose the token path */
-        strncpy(token_path, home_dir, strlen(home_dir));
+        strncpy(token_path, home_dir, MAX_PATH);
         strncat(token_path, "/", strlen("/"));
         strncat(token_path, TOKEN_FILENAME, sizeof(TOKEN_FILENAME) + 1);
     }
@@ -756,6 +757,7 @@ wamr_pal_init(const struct wamr_pal_attr *args)
         std::cout << "Fail to initialize enclave." << std::endl;
         return 1;
     }
+    return 0;
 }
 
 int


### PR DESCRIPTION
fix the warnings as below:

App/App.cpp: In function ‘int wamr_pal_init(const wamr_pal_attr*)’:
App/App.cpp:759:1: warning: control reaches end of non-void function [-Wreturn-type]
  759 | }
      | ^
In file included from /usr/include/string.h:495,
                 from App/App.cpp:9:
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘int enclave_init(sgx_enclave_id_t*)’ at App/App.cpp:104:16:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:34: warning: ‘char* __builtin___strncpy_chk(char*, const char*, long unsigned int, long unsigned int)’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
App/App.cpp: In function ‘int enclave_init(sgx_enclave_id_t*)’:
App/App.cpp:102:16: note: length computed here
  102 |         (strlen(home_dir) + strlen("/") + sizeof(TOKEN_FILENAME) + 1) <= MAX_PATH) {
      |          ~~~~~~^~~~~~~~~~

Signed-off-by: LiFeng <lifeng68@huawei.com>