### PR TITLE
Enable call wasm-c-api native func directly from interpreter (#656)

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.h
+++ b/core/iwasm/common/wasm_runtime_common.h
@@ -796,6 +796,12 @@ uint32
 wasm_runtime_get_memory_data_size(const WASMModuleInstanceCommon *module_inst_comm,
                                   uint32 memory_inst_idx);
 
+bool
+wasm_runtime_invoke_c_api_native(WASMModuleInstanceCommon *module_inst,
+                                 void *func_ptr, WASMType *func_type,
+                                 uint32 argc, uint32 *argv,
+                                 bool with_env, void *wasm_c_api_env);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -1534,7 +1534,9 @@ aot_create_comp_context(AOTCompData *comp_data,
     LLVMAddInstructionCombiningPass(comp_ctx->pass_mgr);
     LLVMAddCFGSimplificationPass(comp_ctx->pass_mgr);
     LLVMAddJumpThreadingPass(comp_ctx->pass_mgr);
+#if LLVM_VERSION_MAJOR < 12
     LLVMAddConstantPropagationPass(comp_ctx->pass_mgr);
+#endif
     LLVMAddIndVarSimplifyPass(comp_ctx->pass_mgr);
 
     if (!option->is_jit_mode) {

--- a/core/iwasm/compilation/aot_llvm.h
+++ b/core/iwasm/compilation/aot_llvm.h
@@ -7,6 +7,7 @@
 #define _AOT_LLVM_H_
 
 #include "aot.h"
+#include "llvm/Config/llvm-config.h"
 #include "llvm-c/Types.h"
 #include "llvm-c/Target.h"
 #include "llvm-c/Core.h"

--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -186,6 +186,8 @@ typedef struct WASMFunctionImport {
     WASMModule *import_module;
     WASMFunction *import_func_linked;
 #endif
+    bool call_conv_wasm_c_api;
+    bool wasm_c_api_with_env;
 } WASMFunctionImport;
 
 typedef struct WASMGlobalImport {

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -753,7 +753,18 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
         return;
     }
 
-    if (!func_import->call_conv_raw) {
+    if (func_import->call_conv_wasm_c_api) {
+        ret = wasm_runtime_invoke_c_api_native(
+          (WASMModuleInstanceCommon *)module_inst,
+          func_import->func_ptr_linked, func_import->func_type,
+          cur_func->param_cell_num, frame->lp,
+          func_import->wasm_c_api_with_env, func_import->attachment);
+        if (ret) {
+            argv_ret[0] = frame->lp[0];
+            argv_ret[1] = frame->lp[1];
+        }
+    }
+    else if (!func_import->call_conv_raw) {
         ret = wasm_runtime_invoke_native(exec_env, func_import->func_ptr_linked,
                                          func_import->func_type, func_import->signature,
                                          func_import->attachment,

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -826,7 +826,18 @@ wasm_interp_call_func_native(WASMModuleInstance *module_inst,
         return;
     }
 
-    if (!func_import->call_conv_raw) {
+    if (func_import->call_conv_wasm_c_api) {
+        ret = wasm_runtime_invoke_c_api_native(
+          (WASMModuleInstanceCommon *)module_inst,
+          func_import->func_ptr_linked, func_import->func_type,
+          cur_func->param_cell_num, frame->lp,
+          func_import->wasm_c_api_with_env, func_import->attachment);
+        if (ret) {
+            argv_ret[0] = frame->lp[0];
+            argv_ret[1] = frame->lp[1];
+        }
+    }
+    else if (!func_import->call_conv_raw) {
         ret = wasm_runtime_invoke_native(exec_env, func_import->func_ptr_linked,
                                          func_import->func_type, func_import->signature,
                                          func_import->attachment,

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -2304,7 +2304,7 @@ check_table_index(const WASMModule *module, uint32 table_index,
       !wasm_get_ref_types_flag() &&
 #endif
       table_index != 0) {
-        set_error_buf(error_buf, error_buf_size, "zero flag expected");
+        set_error_buf(error_buf, error_buf_size, "zero byte expected");
         return false;
     }
 
@@ -7472,13 +7472,8 @@ handle_op_block_and_loop:
                 CHECK_MEMORY();
                 /* reserved byte 0x00 */
                 if (*p++ != 0x00) {
-#if WASM_ENABLE_REF_TYPES != 0
                     set_error_buf(error_buf, error_buf_size,
                                   "zero byte expected");
-#else
-                    set_error_buf(error_buf, error_buf_size,
-                                  "zero flag expected");
-#endif
                     goto fail;
                 }
                 PUSH_I32();
@@ -7490,13 +7485,8 @@ handle_op_block_and_loop:
                 CHECK_MEMORY();
                 /* reserved byte 0x00 */
                 if (*p++ != 0x00) {
-#if WASM_ENABLE_REF_TYPES != 0
                     set_error_buf(error_buf, error_buf_size,
                                   "zero byte expected");
-#else
-                    set_error_buf(error_buf, error_buf_size,
-                                  "zero flag expected");
-#endif
                     goto fail;
                 }
                 POP_AND_PUSH(VALUE_TYPE_I32, VALUE_TYPE_I32);
@@ -7811,7 +7801,7 @@ handle_op_block_and_loop:
                         goto fail_unknown_memory;
 
                     if (*p++ != 0x00)
-                        goto fail_zero_flag_expected;
+                        goto fail_zero_byte_expected;
 
                     if (data_seg_idx >= module->data_seg_count) {
                         set_error_buf_v(error_buf, error_buf_size,
@@ -7848,7 +7838,7 @@ handle_op_block_and_loop:
                 {
                     /* both src and dst memory index should be 0 */
                     if (*(int16*)p != 0x0000)
-                        goto fail_zero_flag_expected;
+                        goto fail_zero_byte_expected;
                     p += 2;
 
                     if (module->import_memory_count == 0 && module->memory_count == 0)
@@ -7862,7 +7852,7 @@ handle_op_block_and_loop:
                 case WASM_OP_MEMORY_FILL:
                 {
                     if (*p++ != 0x00) {
-                        goto fail_zero_flag_expected;
+                        goto fail_zero_byte_expected;
                     }
                     if (module->import_memory_count == 0 && module->memory_count == 0) {
                         goto fail_unknown_memory;
@@ -7872,9 +7862,9 @@ handle_op_block_and_loop:
                     POP_I32();
                     POP_I32();
                     break;
-fail_zero_flag_expected:
+fail_zero_byte_expected:
                     set_error_buf(error_buf, error_buf_size,
-                                  "zero flag expected");
+                                  "zero byte expected");
                     goto fail;
 
 fail_unknown_memory:
@@ -8460,7 +8450,7 @@ fail_data_cnt_sec_require:
                         /* reserved byte 0x00 */
                         if (*p++ != 0x00) {
                             set_error_buf(error_buf, error_buf_size,
-                                          "zero flag expected");
+                                          "zero byte expected");
                             goto fail;
                         }
                         break;

--- a/samples/wasm-c-api/CMakeLists.txt
+++ b/samples/wasm-c-api/CMakeLists.txt
@@ -105,32 +105,30 @@ foreach(EX ${EXAMPLES})
   if (MSVC)
     target_compile_definitions(${EX} PRIVATE WASM_API_EXTERN=)
   endif()
-endforeach()
 
-# wat to wasm
-foreach(EX ${EXAMPLES})
-  set(SRC ${CMAKE_CURRENT_LIST_DIR}/src/${EX}.wat)
+  # wat to wasm
+  set(WAT ${CMAKE_CURRENT_LIST_DIR}/src/${EX}.wat)
 
-  add_custom_target(${EX}_WASM ALL
-    COMMAND ${WAT2WASM} ${SRC} -o ${PROJECT_BINARY_DIR}/${EX}.wasm
-    DEPENDS ${SRC}
+  add_custom_target(${EX}_WASM
+    COMMAND ${WAT2WASM} ${WAT} -o ${PROJECT_BINARY_DIR}/${EX}.wasm
+    DEPENDS ${WAT}
     BYPRODUCTS ${PROJECT_BINARY_DIR}/${EX}.wasm
     VERBATIM
-    SOURCES ${SRC}
   )
+  add_dependencies(${EX} ${EX}_WASM)
 
   # generate .aot file
   if(${WAMR_BUILD_AOT} EQUAL 1)
     if(EXISTS ${WAMRC})
-      add_custom_target(${EX}_AOT ALL
+      add_custom_target(${EX}_AOT
         COMMAND ${WAMRC} -o ${PROJECT_BINARY_DIR}/${EX}.aot
           ${PROJECT_BINARY_DIR}/${EX}.wasm
-        DEPENDS ${PROJECT_BINARY_DIR}/${EX}.wasm
+        DEPENDS ${EX}_WASM
         BYPRODUCTS ${PROJECT_BINARY_DIR}/${EX}.aot
         VERBATIM
-        SOURCES ${SRC}
         COMMENT "generate a aot file ${PROJECT_BINARY_DIR}/${EX}.aot"
       )
+      add_dependencies(${EX} ${EX}_AOT)
     endif()
   endif()
 endforeach()

--- a/samples/wasm-c-api/src/callback_chain.c
+++ b/samples/wasm-c-api/src/callback_chain.c
@@ -83,7 +83,7 @@ DEFINE_FUNCTION(log)
         return NULL;
     }
 
-    if (data[length.of.i32]) {
+    if (data[length.of.i32 - 1]) {
         printf("> Error terminated character\n");
         return NULL;
     }
@@ -188,7 +188,11 @@ main(int argc, const char *argv[])
 
     // Load binary.
     printf("Loading binary...\n");
+#if WASM_ENABLE_AOT != 0 && WASM_ENABLE_INTERP == 0
+    FILE *file = fopen("callback_chain.aot", "rb");
+#else
     FILE *file = fopen("callback_chain.wasm", "rb");
+#endif
     if (!file) {
         printf("> Error loading module!\n");
         return 1;


### PR DESCRIPTION
And update loader error messages for latest spec cases, fix aot compiler build error based on latest LLVM code base.