### PR TITLE
Implement wasm-c-api wasm_config related APIs (#665)

### DIFF
--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -264,14 +264,29 @@ aot_compile_wasm_file_init();
 void
 aot_compile_wasm_file_destroy();
 
-uint8*
-aot_compile_wasm_file(const uint8 *wasm_file_buf, uint32 wasm_file_size,
-                      uint32 opt_level, uint32 size_level,
-                      char *error_buf, uint32 error_buf_size,
+uint8 *
+aot_compile_wasm_file(const uint8 *wasm_file_buf,
+                      uint32 wasm_file_size,
+                      uint32 opt_level,
+                      uint32 size_level,
+                      char *error_buf,
+                      uint32 error_buf_size,
                       uint32 *p_aot_file_size);
 #endif
 
 /* Runtime Environment */
+own wasm_config_t *
+wasm_config_new(void)
+{
+    return NULL;
+}
+
+void
+wasm_config_delete(own wasm_config_t *config)
+{
+    (void)config;
+}
+
 static void
 wasm_engine_delete_internal(wasm_engine_t *engine)
 {
@@ -351,7 +366,7 @@ wasm_engine_new_internal(mem_alloc_type_t type, const MemAllocOption *opts)
 /* global engine instance */
 static wasm_engine_t *singleton_engine = NULL;
 
-wasm_engine_t *
+own wasm_engine_t *
 wasm_engine_new()
 {
     if (!singleton_engine) {
@@ -361,7 +376,14 @@ wasm_engine_new()
     return singleton_engine;
 }
 
-wasm_engine_t *
+own wasm_engine_t *
+wasm_engine_new_with_config(own wasm_config_t *config)
+{
+    (void)config;
+    return wasm_engine_new();
+}
+
+own wasm_engine_t *
 wasm_engine_new_with_args(mem_alloc_type_t type, const MemAllocOption *opts)
 {
     if (!singleton_engine) {

--- a/core/iwasm/include/wasm_c_api.h
+++ b/core/iwasm/include/wasm_c_api.h
@@ -145,6 +145,37 @@ WASM_DECLARE_OWN(engine)
 WASM_API_EXTERN own wasm_engine_t* wasm_engine_new(void);
 WASM_API_EXTERN own wasm_engine_t* wasm_engine_new_with_config(own wasm_config_t*);
 
+#ifndef MEM_ALLOC_OPTION_DEFINED
+#define MEM_ALLOC_OPTION_DEFINED
+/* same definition from wasm_export.h */
+/* Memory allocator type */
+typedef enum {
+    /* pool mode, allocate memory from user defined heap buffer */
+    Alloc_With_Pool = 0,
+    /* user allocator mode, allocate memory from user defined
+       malloc function */
+    Alloc_With_Allocator,
+    /* system allocator mode, allocate memory from system allocator,
+       or, platform's os_malloc function */
+    Alloc_With_System_Allocator,
+} mem_alloc_type_t;
+
+/* Memory allocator option */
+typedef union MemAllocOption {
+    struct {
+        void *heap_buf;
+        uint32_t heap_size;
+    } pool;
+    struct {
+        void *malloc_func;
+        void *realloc_func;
+        void *free_func;
+    } allocator;
+} MemAllocOption;
+#endif
+
+WASM_API_EXTERN own wasm_engine_t *
+wasm_engine_new_with_args(mem_alloc_type_t type, const MemAllocOption *opts);
 
 // Store
 

--- a/core/iwasm/include/wasm_export.h
+++ b/core/iwasm/include/wasm_export.h
@@ -93,6 +93,8 @@ typedef enum {
     Package_Type_Unknown = 0xFFFF
 } package_type_t;
 
+#ifndef MEM_ALLOC_OPTION_DEFINED
+#define MEM_ALLOC_OPTION_DEFINED
 /* Memory allocator type */
 typedef enum {
     /* pool mode, allocate memory from user defined heap buffer */
@@ -117,6 +119,7 @@ typedef union MemAllocOption {
         void *free_func;
     } allocator;
 } MemAllocOption;
+#endif
 
 /* WASM runtime initialize arguments */
 typedef struct RuntimeInitArgs {

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -3371,6 +3371,7 @@ label_pop_csp_n:
     wasm_set_exception(module, "out of bounds memory access");
 
   got_exception:
+    SYNC_ALL_TO_FRAME();
     return;
 
 #if WASM_ENABLE_LABELS_AS_VALUES == 0

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -3428,6 +3428,7 @@ recover_br_info:
     wasm_set_exception(module, "out of bounds memory access");
 
   got_exception:
+    SYNC_ALL_TO_FRAME();
     return;
 
 #if WASM_ENABLE_LABELS_AS_VALUES == 0

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -2463,6 +2463,7 @@ wasm_interp_dump_call_stack(struct WASMExecEnv *exec_env)
         WASMCApiFrame frame = { 0 };
         WASMFunctionInstance *func_inst = cur_frame->function;
         const char *func_name = NULL;
+        const uint8 *func_code_base = NULL;
 
         if (!func_inst) {
             cur_frame = cur_frame->prev_frame;
@@ -2473,8 +2474,14 @@ wasm_interp_dump_call_stack(struct WASMExecEnv *exec_env)
         frame.instance = module_inst;
         frame.module_offset = 0;
         frame.func_index = func_inst - module_inst->functions;
-        frame.func_offset =
-          cur_frame->ip ? cur_frame->ip - func_inst->u.func->code : 0;
+
+        func_code_base = wasm_get_func_code(func_inst);
+        if (!cur_frame->ip || !func_code_base) {
+            frame.func_offset = 0;
+        }
+        else {
+            frame.func_offset = cur_frame->ip - func_code_base;
+        }
 
         /* look for the function name */
         if (func_inst->is_import_func) {

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -97,7 +97,7 @@ endif ()
 # UNDEFINED BEHAVIOR
 # refer to https://en.cppreference.com/w/cpp/language/ub
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=bounds-strict,undefined -fno-sanitize-recover")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined -fno-sanitize-recover")
 endif()
 
 set (WAMR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)


### PR DESCRIPTION
And add wasm_engine_new_with_args() declaration in wasm_c_api.h
Fix wasm-c-api frame func_offset issue in fast interp mode
Remove sanitize compiler flag in product-mini linux CMakeLists.txt