### PR TITLE
Implement wasm_runtime_init_thread_env for Windows platform (#683)

### DIFF
--- a/core/iwasm/aot/aot_runtime.c
+++ b/core/iwasm/aot/aot_runtime.c
@@ -1324,7 +1324,7 @@ invoke_native_with_hw_bound_check(WASMExecEnv *exec_env, void *func_ptr,
     uint16 param_count = func_type->param_count;
     uint16 result_count = func_type->result_count;
     const uint8 *types = func_type->types;
-#if BH_PLATFORM_WINDOWS
+#ifdef BH_PLATFORM_WINDOWS
     const char *exce;
     int result;
 #endif

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -823,9 +823,19 @@ wasm_runtime_destroy_exec_env(WASMExecEnv *exec_env)
 bool
 wasm_runtime_init_thread_env()
 {
+#ifdef BH_PLATFORM_WINDOWS
+    if (os_thread_env_init() != 0)
+        return false;
+#endif
+
 #if WASM_ENABLE_AOT != 0
 #ifdef OS_ENABLE_HW_BOUND_CHECK
-    return aot_signal_init();
+    if (!aot_signal_init()) {
+#ifdef BH_PLATFORM_WINDOWS
+        os_thread_env_destroy();
+#endif
+        return false;
+    }
 #endif
 #endif
     return true;
@@ -838,6 +848,10 @@ wasm_runtime_destroy_thread_env()
 #ifdef OS_ENABLE_HW_BOUND_CHECK
     aot_signal_destroy();
 #endif
+#endif
+
+#ifdef BH_PLATFORM_WINDOWS
+    os_thread_env_destroy();
 #endif
 }
 

--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -66,7 +66,7 @@ read_leb(const uint8 *buf, const uint8 *buf_end,
   }
   if (sign && (shift < maxbits) && (byte & 0x40)) {
     /* Sign extend */
-    result |= (uint64)(- (((uint64)1) << shift));
+    result |= (~((uint64)0)) << shift;
   }
   *p_result = result;
   return true;

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -50,7 +50,7 @@ rotl32(uint32 n, uint32 c)
     const uint32 mask = (31);
     c = c % 32;
     c &= mask;
-    return (n<<c) | (n>>( (-c)&mask ));
+    return (n << c) | (n >> ((0 - c) & mask));
 }
 
 static inline uint32
@@ -59,7 +59,7 @@ rotr32(uint32 n, uint32 c)
     const uint32 mask = (31);
     c = c % 32;
     c &= mask;
-    return (n>>c) | (n<<( (-c)&mask ));
+    return (n >> c) | (n << ((0 - c) & mask));
 }
 
 static inline uint64
@@ -68,7 +68,7 @@ rotl64(uint64 n, uint64 c)
     const uint64 mask = (63);
     c = c % 64;
     c &= mask;
-    return (n<<c) | (n>>( (-c)&mask ));
+    return (n << c) | (n >> ((0 - c) & mask));
 }
 
 static inline uint64
@@ -77,7 +77,7 @@ rotr64(uint64 n, uint64 c)
     const uint64 mask = (63);
     c = c % 64;
     c &= mask;
-    return (n>>c) | (n<<( (-c)&mask ));
+    return (n >> c) | (n << ((0 - c) & mask));
 }
 
 static inline double
@@ -2623,7 +2623,7 @@ label_pop_csp_n:
             goto out_of_bounds;
 
           bh_memcpy_s(maddr, linear_mem_size - addr,
-                      data + offset, bytes);
+                      data + offset, (uint32)bytes);
           break;
         }
         case WASM_OP_DATA_DROP:
@@ -2717,9 +2717,9 @@ label_pop_csp_n:
           bh_memcpy_s(
             (uint8 *)(tbl_inst)
               + offsetof(WASMTableInstance, base_addr) + d * sizeof(uint32),
-            (tbl_inst->cur_size - d) * sizeof(uint32),
+            (uint32)((tbl_inst->cur_size - d) * sizeof(uint32)),
             module->module->table_segments[elem_idx].func_indexes + s,
-            n * sizeof(uint32));
+            (uint32)(n * sizeof(uint32)));
 
           break;
         }
@@ -2764,10 +2764,10 @@ label_pop_csp_n:
           bh_memmove_s(
             (uint8 *)(dst_tbl_inst) + offsetof(WASMTableInstance, base_addr)
               + d * sizeof(uint32),
-            (dst_tbl_inst->cur_size - d) * sizeof(uint32),
+            (uint32)((dst_tbl_inst->cur_size - d) * sizeof(uint32)),
             (uint8 *)(src_tbl_inst) + offsetof(WASMTableInstance, base_addr)
               + s * sizeof(uint32),
-            n * sizeof(uint32));
+            (uint32)(n * sizeof(uint32)));
           break;
         }
         case WASM_OP_TABLE_GROW:

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -48,7 +48,7 @@ rotl32(uint32 n, uint32 c)
     const uint32 mask = (31);
     c = c % 32;
     c &= mask;
-    return (n<<c) | (n>>( (-c)&mask ));
+    return (n << c) | (n >> ((0 - c) & mask));
 }
 
 static inline uint32
@@ -57,7 +57,7 @@ rotr32(uint32 n, uint32 c)
     const uint32 mask = (31);
     c = c % 32;
     c &= mask;
-    return (n>>c) | (n<<( (-c)&mask ));
+    return (n >> c) | (n << ((0 - c) & mask));
 }
 
 static inline uint64
@@ -66,7 +66,7 @@ rotl64(uint64 n, uint64 c)
     const uint64 mask = (63);
     c = c % 64;
     c &= mask;
-    return (n<<c) | (n>>( (-c)&mask ));
+    return (n << c) | (n >> ((0 - c) & mask));
 }
 
 static inline uint64
@@ -75,7 +75,7 @@ rotr64(uint64 n, uint64 c)
     const uint64 mask = (63);
     c = c % 64;
     c &= mask;
-    return (n>>c) | (n<<( (-c)&mask ));
+    return (n >> c) | (n << ((0 - c) & mask));
 }
 
 static inline double
@@ -455,7 +455,8 @@ LOAD_PTR(void *addr)
 
 #define DEF_OP_MATH(src_type, src_op_type, method) do {             \
     SET_OPERAND(src_op_type, 2,                                     \
-                method(GET_OPERAND(src_type, src_op_type, 0)));     \
+                (src_type)method(GET_OPERAND(src_type,              \
+                                             src_op_type, 0)));     \
     frame_ip += 4;                                                  \
   } while (0)
 
@@ -2229,7 +2230,7 @@ recover_br_info:
         else if (isnan(b))
             *(float32*)(frame_lp + GET_OFFSET()) = b;
         else
-            *(float32*)(frame_lp + GET_OFFSET()) = wa_fmin(a, b);
+            *(float32*)(frame_lp + GET_OFFSET()) = (float32)wa_fmin(a, b);
         HANDLE_OP_END ();
       }
 
@@ -2245,7 +2246,7 @@ recover_br_info:
         else if (isnan(b))
             *(float32*)(frame_lp + GET_OFFSET()) = b;
         else
-            *(float32*)(frame_lp + GET_OFFSET()) = wa_fmax(a, b);
+            *(float32*)(frame_lp + GET_OFFSET()) = (float32)wa_fmax(a, b);
         HANDLE_OP_END ();
       }
 
@@ -2255,7 +2256,8 @@ recover_br_info:
 
         b = *(float32*)(frame_lp + GET_OFFSET());
         a = *(float32*)(frame_lp + GET_OFFSET());
-        *(float32*)(frame_lp + GET_OFFSET()) = (signbit(b) ? -fabs(a) : fabs(a));
+        *(float32*)(frame_lp + GET_OFFSET()) =
+            (float32)(signbit(b) ? -fabs(a) : fabs(a));
         HANDLE_OP_END ();
       }
 
@@ -2606,7 +2608,8 @@ recover_br_info:
           if (offset + bytes > seg_len)
             goto out_of_bounds;
 
-          bh_memcpy_s(maddr, linear_mem_size - addr, data + offset, bytes);
+          bh_memcpy_s(maddr, linear_mem_size - addr,
+                      data + offset, (uint32)bytes);
           break;
         }
         case WASM_OP_DATA_DROP:
@@ -2695,9 +2698,9 @@ recover_br_info:
             bh_memcpy_s(
               (uint8 *)tbl_inst + offsetof(WASMTableInstance, base_addr)
                 + d * sizeof(uint32),
-              (tbl_inst->cur_size - d) * sizeof(uint32),
+              (uint32)((tbl_inst->cur_size - d) * sizeof(uint32)),
               module->module->table_segments[elem_idx].func_indexes + s,
-              n * sizeof(uint32));
+              (uint32)(n * sizeof(uint32)));
             break;
         }
         case WASM_OP_ELEM_DROP:
@@ -2740,10 +2743,10 @@ recover_br_info:
             bh_memmove_s(
               (uint8 *)dst_tbl_inst + offsetof(WASMTableInstance, base_addr)
                 + d * sizeof(uint32),
-              (dst_tbl_inst->cur_size - d) * sizeof(uint32),
+              (uint32)((dst_tbl_inst->cur_size - d) * sizeof(uint32)),
               (uint8 *)src_tbl_inst
                 + offsetof(WASMTableInstance, base_addr) + s * sizeof(uint32),
-              n * sizeof(uint32));
+              (uint32)(n * sizeof(uint32)));
             break;
         }
         case WASM_OP_TABLE_GROW:

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -2485,14 +2485,14 @@ wasm_interp_dump_call_stack(struct WASMExecEnv *exec_env)
         /* place holder, will overwrite it in wasm_c_api */
         frame.instance = module_inst;
         frame.module_offset = 0;
-        frame.func_index = func_inst - module_inst->functions;
+        frame.func_index = (uint32)(func_inst - module_inst->functions);
 
         func_code_base = wasm_get_func_code(func_inst);
         if (!cur_frame->ip || !func_code_base) {
             frame.func_offset = 0;
         }
         else {
-            frame.func_offset = cur_frame->ip - func_code_base;
+            frame.func_offset = (uint32)(cur_frame->ip - func_code_base);
         }
 
         /* look for the function name */

--- a/core/shared/platform/include/platform_api_extension.h
+++ b/core/shared/platform/include/platform_api_extension.h
@@ -85,10 +85,23 @@ int os_thread_detach(korp_tid);
 void os_thread_exit(void *retval);
 
 /**
+ * Initialize current thread environment if current thread
+ * is created by developer but not runtime
+ *
+ * @return 0 if success, -1 otherwise
+ */
+int os_thread_env_init();
+
+/**
+ * Destroy current thread environment
+ */
+void os_thread_env_destroy();
+
+/**
  * Suspend execution of the calling thread for (at least)
  * usec microseconds
  *
- * @param return 0 if success, -1 otherwise
+ * @return 0 if success, -1 otherwise
  */
 int os_usleep(uint32 usec);
 

--- a/product-mini/platforms/alios-things/aos.mk
+++ b/product-mini/platforms/alios-things/aos.mk
@@ -99,6 +99,7 @@ $(NAME)_SOURCES := ${SHARED_ROOT}/platform/alios/alios_platform.c \
                    ${IWASM_ROOT}/common/wasm_native.c \
                    ${IWASM_ROOT}/common/wasm_exec_env.c \
                    ${IWASM_ROOT}/common/wasm_memory.c \
+                   ${IWASM_ROOT}/common/wasm_c_api.c \
                    ${IWASM_ROOT}/common/arch/${INVOKE_NATIVE} \
                    src/main.c
 


### PR DESCRIPTION
Implement wasm_runtime_init_thread_env() for Windows platform by calling os_thread_env_init(): if current thread is created by developer himself but not runtime, developer should call wasm_runtime_init_thread_env() to init the thread environment before calling wasm function, and call wasm_runtime_destroy_thread_env() before thread exits.
And clear compile warnings for Windows platform, fix compile error for AliOS-Things platform

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>