### PR TITLE
Fix CI issues (#781)

### DIFF
--- a/.github/workflows/spec_test.yml
+++ b/.github/workflows/spec_test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths:
       - "core/iwasm/**"
+      - "core/shared/**"
+      - "wamr-compiler/**"
+      - "product-mini/**"
   # allow to be triggered manually
   workflow_dispatch:
 
@@ -41,7 +44,7 @@ jobs:
         with:
           path: ./core/deps/llvm/build/LLVM-13.0.0.tar.gz
           key: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
-          restore-keys: ${{ matrix.os }}-${{ env.LLVM_CACHE_SUFFIX }}
+          restore-keys: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
 
       - name: Build llvm and clang from source
         id: build_llvm
@@ -79,7 +82,7 @@ jobs:
         with:
           path: ./core/deps/llvm/build/LLVM-13.0.0.tar.gz
           key: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
-          restore-keys: ${{ matrix.os }}-${{ env.LLVM_CACHE_SUFFIX }}
+          restore-keys: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
 
       - name: Quit if cache miss
         if: steps.cache_llvm.outputs.cache-hit != 'true'


### PR DESCRIPTION
Fix spec_test.yml llvm-library cache key name invalid issue.
Trigger CI when core/shared, product-mini and wamr-compiler change.