### PR TITLE
Enhance spec test workflow to support x86_32 target (#787)

### DIFF
--- a/.github/workflows/spec_test.yml
+++ b/.github/workflows/spec_test.yml
@@ -33,7 +33,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  DEFAULT_TEST_OPTIONS: "-s spec"
   LLVM_CACHE_SUFFIX: "build-llvm_libraries"
+  MULTI_MODULES_TEST_OPTIONS: "-s spec -M"
+  SIMD_TEST_OPTIONS: "-s spec -S"
+  THREADS_TEST_OPTIONS: "-s spec -p"
+  X86_32_TARGET_TEST_OPTIONS: "-m x86_32"
 
 jobs:
   cancel_previous:
@@ -70,21 +75,12 @@ jobs:
         run: mv LLVM-13.0.0-*.tar.gz LLVM-13.0.0.tar.gz
         working-directory: core/deps/llvm/build/
 
-  spec_test_on_ubuntu_2004:
+  spec_test_default:
     needs: build_llvm_libraries
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        test_option: [
-            # DEFAULT
-            "-s spec",
-            # SIMD
-            "-s spec -S",
-            # THREAD
-            "-s spec -p",
-            # MULTI_MODULES
-            "-s spec -M",
-          ]
+        test_option: [ $DEFAULT_TEST_OPTIONS, $SIMD_TEST_OPTIONS ]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -110,4 +106,72 @@ jobs:
 
       - name: run spec tests
         run: ./test_wamr.sh ${{ matrix.test_option }}
+        working-directory: ./tests/wamr-test-suites
+
+  spec_test_extra:
+    needs: build_llvm_libraries
+    if: ${{ endsWith(github.repository, 'wasm-micro-runtime') }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        test_option: [ $MULTI_MODULES_TEST_OPTIONS, $THREADS_TEST_OPTIONS ]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Get LLVM libraries
+        id: cache_llvm
+        uses: actions/cache@v2
+        with:
+          path: ./core/deps/llvm/build/LLVM-13.0.0.tar.gz
+          key: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
+          restore-keys: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
+
+      - name: Quit if cache miss
+        if: steps.cache_llvm.outputs.cache-hit != 'true'
+        run: echo "::error::can not get prebuilt llvm libraries" && exit 1
+
+      - name: Extract the LLVM package
+        run: tar xf LLVM-13.0.0.tar.gz --strip-components=1
+        working-directory: ./core/deps/llvm/build
+
+      - name: install Ninja
+        run: sudo apt install -y ninja-build
+
+      - name: run spec tests
+        run: ./test_wamr.sh ${{ matrix.test_option }}
+        working-directory: ./tests/wamr-test-suites
+
+  spec_test_x86_32:
+    if: ${{ endsWith(github.repository, 'wasm-micro-runtime') }}
+    needs: build_llvm_libraries
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        test_option: [ $DEFAULT_TEST_OPTIONS, $THREADS_TEST_OPTIONS ]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Get LLVM libraries
+        id: cache_llvm
+        uses: actions/cache@v2
+        with:
+          path: ./core/deps/llvm/build/LLVM-13.0.0.tar.gz
+          key: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
+          restore-keys: ubuntu-20.04-${{ env.LLVM_CACHE_SUFFIX }}
+
+      - name: Quit if cache miss
+        if: steps.cache_llvm.outputs.cache-hit != 'true'
+        run: echo "::error::can not get prebuilt llvm libraries" && exit 1
+
+      - name: Extract the LLVM package
+        run: tar xf LLVM-13.0.0.tar.gz --strip-components=1
+        working-directory: ./core/deps/llvm/build
+
+      - name: install Ninja and x32 support libraries
+        run: sudo apt install -y g++-multilib libgcc-9-dev lib32gcc-9-dev ninja-build
+
+      - name: run spec tests
+        run: ./test_wamr.sh ${{ env.X86_32_TARGET_TEST_OPTIONS }} ${{ matrix.test_option }}
         working-directory: ./tests/wamr-test-suites

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,9 +8,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asian/Shanghai
 
 RUN apt update \
-  && apt install -y apt-transport-https ca-certificates gnupg \
-      tzdata lsb-release software-properties-common build-essential \
-      apt-utils curl wget git tree unzip zip vim
+  && apt install -y apt-transport-https apt-utils build-essential \
+      ca-certificates curl g++-multilib git gnupg \
+      libgcc-9-dev lib32gcc-9-dev lsb-release \
+      ninja-build  ocaml ocamlbuild python2.7 \
+      software-properties-common tree tzdata \
+      unzip url valgrind vim wget zip
 
 #
 # CMAKE (https://apt.kitware.com/)
@@ -33,7 +36,7 @@ RUN cd /opt/emsdk \
 
 #
 #install wabt
-ARG WABT_VER=1.0.23
+ARG WABT_VER=1.0.24
 RUN wget -c https://github.com/WebAssembly/wabt/releases/download/${WABT_VER}/wabt-${WABT_VER}-ubuntu.tar.gz -P /opt
 RUN tar xf /opt/wabt-${WABT_VER}-ubuntu.tar.gz -C /opt \
   && ln -fs /opt/wabt-${WABT_VER} /opt/wabt
@@ -58,16 +61,6 @@ RUN chmod a+x /opt/bazelisk/bazelisk-linux-amd64 \
 
 # set path
 RUN echo "PATH=/opt/clang_llvm/bin:/opt/wasi-sdk/bin:/opt/wabt/bin:/opt/binaryen/bin:/opt/bazelisk:${PATH}" >> /root/.bashrc
-
-#
-# install
-RUN apt update \
-  && apt install -y ninja-build python2.7 valgrind
-
-#
-# ocaml
-RUN apt update \
-  && apt install -y ocaml ocamlbuild
 
 #
 # PS

--- a/core/iwasm/aot/arch/aot_reloc_x86_32.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_32.c
@@ -7,6 +7,7 @@
 
 #define R_386_32 1   /* Direct 32 bit  */
 #define R_386_PC32 2 /* PC relative 32 bit */
+#define R_386_PLT32 4 /* 32bit address ProcedureLinkageTable */
 
 #if !defined(_WIN32) && !defined(_WIN32_)
 /* clang-format off */
@@ -119,6 +120,11 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
             break;
         }
 
+        /*
+         * Handle R_386_PLT32 like R_386_PC32 since it should be able to reach
+         * any 32 bit address
+         */
+        case R_386_PLT32:
         case R_386_PC32:
         {
             int32 value;

--- a/tests/wamr-test-suites/spec-test-script/all.sh
+++ b/tests/wamr-test-suites/spec-test-script/all.sh
@@ -7,7 +7,7 @@
 
 # exit if meet an exception
 function DEBUG() {
-  [[ -n $(env | grep "\<DEBUG\>") ]] && $@
+    [[ -n $(env | grep "\<DEBUG\>") ]] && $@
 }
 DEBUG set -xevu
 
@@ -25,11 +25,11 @@ IWASM_CMD="../../../product-mini/platforms/${PLATFORM}/build/iwasm"
 # "comments" is for runtest.py
 
 IGNORE_LIST=(
-  "comments" "inline-module" "imports" "linking" "names"
+    "comments" "inline-module" "imports" "linking" "names"
 )
 
 readonly -a MULTI_MODULE_LIST=(
-  "imports" "linking"
+    "imports" "linking"
 )
 
 SGX_IGNORE_LIST=("conversions" "f32_bitwise" "f64_bitwise")
@@ -37,14 +37,12 @@ SGX_IGNORE_LIST=("conversions" "f32_bitwise" "f64_bitwise")
 # these cases run failed due to native stack overflow check failed
 SGX_AOT_IGNORE_LIST=("call_indirect" "call" "fac" "skip-stack-guard-page")
 
-function usage()
-{
+function usage() {
     echo "Usage: all.sh [-t] [-m <x86_64|x86_32|ARMV7_VFP|THUMBV7_VFP>] [-M] [-x] [-S] [-r]"
     exit 1
 }
 
-function run_case_w_aot()
-{
+function run_case_w_aot() {
     local test_case=$1
     echo "============> run ${test_case} with AOT"
     python2.7 runtest.py \
@@ -56,26 +54,25 @@ function run_case_w_aot()
         ${SGX_OPT} \
         ${SIMD_OPT} \
         ${REF_TYPES_OPT}
-        #--no_cleanup
+    #--no_cleanup
     if [[ $? != 0 ]]; then
         echo "============> run ${test_case} failed"
         exit 1
     fi
 }
 
-function run_case_wo_aot()
-{
+function run_case_wo_aot() {
     local test_case=$1
     echo "============> run ${test_case}"
     python2.7 runtest.py \
         --wast2wasm ${WAST2WASM_CMD} \
         --interpreter ${IWASM_CMD} \
-        ${SPEC_TEST_DIR}/${test_case}\
+        ${SPEC_TEST_DIR}/${test_case} \
         --aot-compiler ${WAMRC_CMD} \
         ${SGX_OPT} \
         ${SIMD_OPT} \
         ${REF_TYPES_OPT}
-        #--no_cleanup
+    #--no_cleanup
     if [[ $? != 0 ]]; then
         echo "============> run ${test_case} failed"
         exit 1
@@ -90,35 +87,33 @@ SIMD_OPT=""
 REF_TYPES_OPT=""
 while getopts ":Mm:txSr" opt; do
     case $opt in
-        t) AOT=true ;;
-        m)
-            TARGET=$OPTARG
-            if [[ ${TARGET} == 'X86_32' ]];then
-                TARGET='i386'
-            elif [[ ${TARGET} == 'X86_64' ]];then
-                TARGET='x86_64'
-            elif [[ ${TARGET} == 'ARMV7_VFP' ]];then
-                TARGET='armv7'
-            elif [[ ${TARGET} == 'THUMBV7_VFP' ]];then
-                TARGET='thumbv7'
-            elif [[ ${TARGET} == 'RISCV64' || ${TARGET} == 'RISCV64_LP64D' ]];then
-                TARGET='riscv64_lp64d'
-            elif [[ ${TARGET} == 'RISCV64_LP64' ]];then
-                TARGET='riscv64_lp64'
-            else
-                usage
-            fi
-            ;;
-        M) ENABLE_MULTI_MODULE=1 ;;
-        x) SGX_OPT="--sgx" ;;
-        S) SIMD_OPT="--simd" ;;
-        r) REF_TYPES_OPT="--ref_types" ;;
-        *) usage ;;
+    t) AOT=true ;;
+    m)
+        TARGET=$OPTARG
+        if [[ ${TARGET} == 'X86_32' ]]; then
+            TARGET='i386'
+        elif [[ ${TARGET} == 'X86_64' ]]; then
+            TARGET='x86_64'
+        elif [[ ${TARGET} == 'ARMV7_VFP' ]]; then
+            TARGET='armv7'
+        elif [[ ${TARGET} == 'THUMBV7_VFP' ]]; then
+            TARGET='thumbv7'
+        elif [[ ${TARGET} == 'RISCV64' || ${TARGET} == 'RISCV64_LP64D' ]]; then
+            TARGET='riscv64_lp64d'
+        elif [[ ${TARGET} == 'RISCV64_LP64' ]]; then
+            TARGET='riscv64_lp64'
+        else
+            usage
+        fi ;;
+    M) ENABLE_MULTI_MODULE=1 ;;
+    x) SGX_OPT="--sgx" ;;
+    S) SIMD_OPT="--simd" ;;
+    r) REF_TYPES_OPT="--ref_types" ;;
+    *) usage ;;
     esac
 done
 
-function contain()
-{
+function contain() {
     # [$1, $-1)
     local list=${@:0:${#}}
     # [$-1]
@@ -126,12 +121,16 @@ function contain()
     [[ ${list} =~ (^| )${item}($| ) ]] && return 0 || return 1
 }
 
-if [[ ${SGX_OPT} ]];then
+if [[ ${SGX_OPT} ]]; then
     IWASM_CMD="../../../product-mini/platforms/linux-sgx/enclave-sample/iwasm"
     IGNORE_LIST+=("${SGX_IGNORE_LIST[@]}")
-    if [[ "true" == ${AOT} ]];then
+    if [[ "true" == ${AOT} ]]; then
         IGNORE_LIST+=("${SGX_AOT_IGNORE_LIST[@]}")
     fi
+fi
+
+if [[ ${TARGET} == "i386" ]]; then
+    IGNORE_LIST+=("float_exprs")
 fi
 
 declare -i COUNTER=0
@@ -143,9 +142,9 @@ for wast in $(find ${SPEC_TEST_DIR} -name "*.wast" -type f | sort -n); do
         echo "============> ignore ${wast}"
         continue
     else
-        [[ "true" == ${AOT} ]] && run_case_w_aot ${wast} \
-            || run_case_wo_aot ${wast}
-        (( COUNTER += 1))
+        [[ "true" == ${AOT} ]] && run_case_w_aot ${wast} ||
+            run_case_wo_aot ${wast}
+        ((COUNTER += 1))
     fi
 done
 
@@ -154,7 +153,7 @@ if [[ "false" == ${AOT} && 1 == ${ENABLE_MULTI_MODULE} ]]; then
     echo "============> run cases about multi module"
     for wast in ${MULTI_MODULE_LIST[@]}; do
         run_case_wo_aot ${wast}.wast
-        (( COUNTER += 1))
+        ((COUNTER += 1))
     done
 fi
 

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -584,6 +584,11 @@ function trigger()
             ;;
 
             "jit")
+                if [[ ${TARGET} == "X86_32" ]]; then
+                    echo "does not support an X86_32 target in JIT mode, bypass"
+                    continue
+                fi
+
                 echo "work in jit mode"
                 # jit
                 BUILD_FLAGS="$JIT_COMPILE_FLAGS $EXTRA_COMPILE_FLAGS"


### PR DESCRIPTION
Enable test spec cases on x86_32 target when PR is created.
And Format shell script with [shellfmt](https://marketplace.visualstudio.com/items?itemName=foxundermoon.shell-format).