### PR TITLE
aot_reloc_x86_64: Fix pointer overflows (#809)

### DIFF
--- a/core/iwasm/aot/arch/aot_reloc_x86_64.c
+++ b/core/iwasm/aot/arch/aot_reloc_x86_64.c
@@ -225,12 +225,13 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
                       - get_plt_table_size()
                       + get_plt_item_size() * symbol_index;
                 target_addr = (intptr_t) /* L + A - P */
-                    (plt + reloc_addend - (target_section_addr + reloc_offset));
+                    ((uintptr_t)plt + reloc_addend
+                     - (uintptr_t)(target_section_addr + reloc_offset));
             }
             else {
                 target_addr = (intptr_t) /* L + A - P */
-                    ((uint8 *)symbol_addr + reloc_addend
-                     - (target_section_addr + reloc_offset));
+                    ((uintptr_t)symbol_addr + reloc_addend
+                     - (uintptr_t)(target_section_addr + reloc_offset));
             }
 
 #if defined(BH_PLATFORM_WINDOWS)


### PR DESCRIPTION
Fix pointer overflow of `(uint8 *)symbol_addr + reloc_addend` detected by UBSan:
```
core/iwasm/aot/arch/aot_reloc_x86_64.c:232:43: runtime error: addition of unsigned offset to 0x000041209004 overflowed to 0x000041209000
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior core/iwasm/aot/arch/aot_reloc_x86_64.c:232:43
```