### PR TITLE
Implement loading ref type of global/table and fix some issues (#840)

### DIFF
--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -76,6 +76,8 @@ extern "C" {
 /* = WASM_OP_REF_NULL */
 #define INIT_EXPR_TYPE_REFNULL_CONST 0xD0
 #define INIT_EXPR_TYPE_GET_GLOBAL 0x23
+#define INIT_EXPR_TYPE_RTT_CANON 0x30
+#define INIT_EXPR_TYPE_RTT_SUB 0x31
 #define INIT_EXPR_TYPE_ERROR 0xff
 
 #define WASM_MAGIC_NUMBER 0x6d736100
@@ -133,6 +135,18 @@ typedef union V128 {
     float64 f64x2[2];
 } V128;
 
+#if WASM_ENABLE_GC != 0
+typedef struct RttSubInitInfo {
+    /* Which opcode to init the parent type of rtt.sub,
+       currently it can only be rtt.canon */
+    uint8 parent_init_expr_type;
+    /* The type index of rtt.canon */
+    uint32 parent_type_idx;
+    /* The type index of rtt.sub */
+    uint32 sub_type_idx;
+} RttSubInitInfo;
+#endif
+
 typedef union WASMValue {
     int32 i32;
     uint32 u32;
@@ -142,13 +156,15 @@ typedef union WASMValue {
     uint64 u64;
     float32 f32;
     float64 f64;
-    uintptr_t addr;
     V128 v128;
+#if WASM_ENABLE_GC != 0
+    RttSubInitInfo rtt_sub;
+#endif
 } WASMValue;
 
 typedef struct InitializerExpression {
-    /* type of INIT_EXPR_TYPE_XXX */
-    /* it actually is instr, in some places, requires constant only */
+    /* type of INIT_EXPR_TYPE_XXX, which is an instruction of
+       constant expression */
     uint8 init_expr_type;
     WASMValue u;
 } InitializerExpression;
@@ -248,7 +264,14 @@ typedef union WASMRefType {
 } WASMRefType;
 
 typedef struct WASMRefTypeMap {
+    /**
+     * The type index of a type array, which only stores
+     * the first byte of the type, e.g. WASMFuncType.types,
+     * WASMStructType.fields
+     */
     uint16 index;
+    /* The full type info if the type cannot be described
+       with one byte */
     WASMRefType *ref_type;
 } WASMRefTypeMap;
 #endif /* end of WASM_ENABLE_GC */
@@ -301,7 +324,9 @@ typedef struct WASMFuncType {
     WASMRefTypeMap *ref_type_maps;
 #endif
 
-    /* types of params and results */
+    /* types of params and results, only store the first byte
+     * of the type, if it cannot be described with one byte,
+     * then the full type info is stored in ref_type_maps */
     uint8 types[1];
 } WASMFuncType;
 
@@ -331,6 +356,10 @@ typedef struct WASMStructType {
     uint16 ref_type_map_count;
     WASMRefTypeMap *ref_type_maps;
 
+    /* Field info, note that fields[i]->field_type only stores
+     * the first byte of the field type, if it cannot be described
+     * with one byte, then the full field type info is stored in
+     * ref_type_maps */
     WASMStructFieldType fields[1];
 } WASMStructType;
 
@@ -346,17 +375,24 @@ typedef struct WASMArrayType {
     uint16 ref_count;
 
     uint16 elem_flags;
-    WASMRefType elem_type;
+    uint8 elem_type;
+    /* The full elem type info if the elem type cannot be
+       described with one byte */
+    WASMRefType *elem_ref_type;
 } WASMArrayType;
 #endif
 
 typedef struct WASMTable {
     uint8 elem_type;
-    uint32 flags;
+    /* 0: no max size, not shared, 1: hax max size, 2: shared */
+    uint8 flags;
+    bool possible_grow;
     uint32 init_size;
     /* specified if (flags & 1), else it is 0x10000 */
     uint32 max_size;
-    bool possible_grow;
+#if WASM_ENABLE_GC != 0
+    WASMRefType *elem_ref_type;
+#endif
 } WASMTable;
 
 typedef struct WASMMemory {
@@ -370,11 +406,15 @@ typedef struct WASMTableImport {
     char *module_name;
     char *field_name;
     uint8 elem_type;
-    uint32 flags;
+    /* 0: no max size, 1: has max size */
+    uint8 flags;
+    bool possible_grow;
     uint32 init_size;
     /* specified if (flags & 1), else it is 0x10000 */
     uint32 max_size;
-    bool possible_grow;
+#if WASM_ENABLE_GC != 0
+    WASMRefType *elem_ref_type;
+#endif
 #if WASM_ENABLE_MULTI_MODULE != 0
     WASMModule *import_module;
     WASMTable *import_table_linked;
@@ -419,9 +459,12 @@ typedef struct WASMGlobalImport {
     char *field_name;
     uint8 type;
     bool is_mutable;
+    bool is_linked;
     /* global data after linked */
     WASMValue global_data_linked;
-    bool is_linked;
+#if WASM_ENABLE_GC != 0
+    WASMRefType *ref_type;
+#endif
 #if WASM_ENABLE_MULTI_MODULE != 0
     /* imported function pointer after linked */
     /* TODO: remove if not needed */
@@ -483,6 +526,9 @@ struct WASMFunction {
 struct WASMGlobal {
     uint8 type;
     bool is_mutable;
+#if WASM_ENABLE_GC != 0
+    WASMRefType *ref_type;
+#endif
     InitializerExpression init_expr;
 };
 
@@ -716,28 +762,31 @@ wasm_string_equal(const char *s1, const char *s2)
 
 /**
  * Return the byte size of value type.
- *
  */
 inline static uint32
 wasm_value_type_size(uint8 value_type)
 {
-    switch (value_type) {
-        case VALUE_TYPE_I32:
-        case VALUE_TYPE_F32:
-#if WASM_ENABLE_REF_TYPES != 0
-        case VALUE_TYPE_FUNCREF:
-        case VALUE_TYPE_EXTERNREF:
-#endif
-            return sizeof(int32);
-        case VALUE_TYPE_I64:
-        case VALUE_TYPE_F64:
-            return sizeof(int64);
+    if (value_type == VALUE_TYPE_VOID)
+        return 0;
+    else if (value_type == VALUE_TYPE_I32 || value_type == VALUE_TYPE_F32)
+        return sizeof(int32);
+    else if (value_type == VALUE_TYPE_I64 || value_type == VALUE_TYPE_F64)
+        return sizeof(int64);
 #if WASM_ENABLE_SIMD != 0
-        case VALUE_TYPE_V128:
-            return sizeof(int64) * 2;
+    else if (value_type == VALUE_TYPE_V128)
+        return sizeof(int64) * 2;
 #endif
-        default:
-            bh_assert(0);
+#if WASM_ENABLE_GC != 0
+    else if (value_type >= (uint8)REF_TYPE_DATAREF
+             && value_type <= (uint8)REF_TYPE_FUNCREF)
+        return sizeof(uintptr_t);
+#elif WASM_ENABLE_REF_TYPES != 0
+    else if (value_type == VALUE_TYPE_FUNCREF
+             || value_type == VALUE_TYPE_EXTERNREF)
+        return sizeof(uint32);
+#endif
+    else {
+        bh_assert(0);
     }
     return 0;
 }
@@ -745,35 +794,7 @@ wasm_value_type_size(uint8 value_type)
 inline static uint16
 wasm_value_type_cell_num(uint8 value_type)
 {
-    if (value_type == VALUE_TYPE_VOID)
-        return 0;
-    else if (value_type == VALUE_TYPE_I32 || value_type == VALUE_TYPE_F32)
-        return 1;
-    else if (value_type == VALUE_TYPE_I64 || value_type == VALUE_TYPE_F64)
-        return 2;
-#if WASM_ENABLE_SIMD != 0
-    else if (value_type == VALUE_TYPE_V128)
-        return 4;
-#endif
-#if WASM_ENABLE_REF_TYPES != 0
-    else if (value_type == VALUE_TYPE_FUNCREF
-             || value_type == VALUE_TYPE_EXTERNREF)
-        return 1;
-#if 0
-        /* TODO: Use pointer to store reference types */
-        return sizeof(uintptr_t) / 4;
-#endif
-#endif
-#if WASM_ENABLE_GC != 0
-    else if (value_type >= (uint8)REF_TYPE_DATAREF
-             && value_type <= (uint8)REF_TYPE_FUNCREF)
-        /* Use pointer to store reference types */
-        return sizeof(uintptr_t) / 4;
-#endif
-    else {
-        bh_assert(0);
-    }
-    return 0;
+    return wasm_value_type_size(value_type) / 4;
 }
 
 inline static uint32

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1340,7 +1340,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 HANDLE_OP_END();
             }
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
             HANDLE_OP(WASM_OP_SELECT_T)
             {
                 uint32 vec_len;
@@ -1432,7 +1432,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 PUSH_I32(func_idx);
                 HANDLE_OP_END();
             }
-#endif /* WASM_ENABLE_REF_TYPES */
+#endif /* (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0) */
 
 #if WASM_ENABLE_GC != 0
             HANDLE_OP(WASM_OP_CALL_REF) { HANDLE_OP_END(); }
@@ -1514,7 +1514,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 switch (local_type) {
                     case VALUE_TYPE_I32:
                     case VALUE_TYPE_F32:
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
                     case VALUE_TYPE_FUNCREF:
                     case VALUE_TYPE_EXTERNREF:
 #endif
@@ -1550,7 +1550,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 switch (local_type) {
                     case VALUE_TYPE_I32:
                     case VALUE_TYPE_F32:
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
                     case VALUE_TYPE_FUNCREF:
                     case VALUE_TYPE_EXTERNREF:
 #endif
@@ -1588,7 +1588,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 switch (local_type) {
                     case VALUE_TYPE_I32:
                     case VALUE_TYPE_F32:
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
                     case VALUE_TYPE_FUNCREF:
                     case VALUE_TYPE_EXTERNREF:
 #endif
@@ -3046,7 +3046,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                         break;
                     }
 #endif /* WASM_ENABLE_BULK_MEMORY */
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
                     case WASM_OP_TABLE_INIT:
                     {
                         uint32 tbl_idx, elem_idx;
@@ -3224,7 +3224,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         break;
                     }
-#endif /* WASM_ENABLE_REF_TYPES */
+#endif /* (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0) */
                     default:
                         wasm_set_exception(module, "unsupported opcode");
                         goto got_exception;
@@ -3605,7 +3605,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if WASM_ENABLE_SHARED_MEMORY == 0
         HANDLE_OP(WASM_OP_ATOMIC_PREFIX)
 #endif
-#if WASM_ENABLE_REF_TYPES == 0
+#if (WASM_ENABLE_GC == 0) && (WASM_ENABLE_REF_TYPES == 0)
         HANDLE_OP(WASM_OP_SELECT_T)
         HANDLE_OP(WASM_OP_TABLE_GET)
         HANDLE_OP(WASM_OP_TABLE_SET)

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1324,7 +1324,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 HANDLE_OP_END();
             }
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
             HANDLE_OP(WASM_OP_TABLE_GET)
             {
                 uint32 tbl_idx, elem_idx;
@@ -1386,7 +1386,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                 PUSH_I32(func_idx);
                 HANDLE_OP_END();
             }
-#endif /* WASM_ENABLE_REF_TYPES */
+#endif /* (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0) */
 
 #if WASM_ENABLE_GC != 0
             HANDLE_OP(WASM_OP_CALL_REF) { HANDLE_OP_END(); }
@@ -2969,7 +2969,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     }
 #endif /* WASM_ENABLE_BULK_MEMORY */
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
                     case WASM_OP_TABLE_INIT:
                     {
                         uint32 tbl_idx, elem_idx;
@@ -3140,7 +3140,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                         break;
                     }
-#endif /* WASM_ENABLE_REF_TYPES */
+#endif /* (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0) */
                     default:
                         wasm_set_exception(module, "unsupported opcode");
                         goto got_exception;
@@ -3540,7 +3540,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 #if WASM_ENABLE_SHARED_MEMORY == 0
         HANDLE_OP(WASM_OP_ATOMIC_PREFIX)
 #endif
-#if WASM_ENABLE_REF_TYPES == 0
+#if (WASM_ENABLE_GC == 0) && (WASM_ENABLE_REF_TYPES == 0)
         HANDLE_OP(WASM_OP_TABLE_GET)
         HANDLE_OP(WASM_OP_TABLE_SET)
         HANDLE_OP(WASM_OP_REF_NULL)

--- a/core/iwasm/interpreter/wasm_mini_loader.c
+++ b/core/iwasm/interpreter/wasm_mini_loader.c
@@ -295,7 +295,7 @@ load_init_expr(const uint8 **p_buf, const uint8 *buf_end,
     }
     CHECK_BUF(p, p_end, 1);
     end_byte = read_uint8(p);
-    bh_assert(end_byte == 0x0b);
+    bh_assert(end_byte == WASM_OP_END);
     *p_buf = p;
 
     (void)end_byte;
@@ -471,7 +471,7 @@ load_table_import(const uint8 **p_buf, const uint8 *buf_end,
     /* now we believe all declaration are ok */
     table->elem_type = declare_elem_type;
     table->init_size = declare_init_size;
-    table->flags = declare_max_size_flag;
+    table->flags = (uint8)declare_max_size_flag;
     table->max_size = declare_max_size;
     return true;
 }
@@ -569,6 +569,7 @@ load_table(const uint8 **p_buf, const uint8 *buf_end, WASMTable *table,
            char *error_buf, uint32 error_buf_size)
 {
     const uint8 *p = *p_buf, *p_end = buf_end, *p_org;
+    uint32 flags;
 
     CHECK_BUF(p, p_end, 1);
     /* 0x70 or 0x6F */
@@ -580,10 +581,11 @@ load_table(const uint8 **p_buf, const uint8 *buf_end, WASMTable *table,
     );
 
     p_org = p;
-    read_leb_uint32(p, p_end, table->flags);
+    read_leb_uint32(p, p_end, flags);
     bh_assert(p - p_org <= 1);
-    bh_assert(table->flags <= 1);
+    bh_assert(flags <= 1);
     (void)p_org;
+    table->flags = (uint8)flags;
 
     read_leb_uint32(p, p_end, table->init_size);
     if (table->flags == 1) {

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -763,7 +763,7 @@ globals_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
                 &(globals[init_expr->u.global_index].initial_value),
                 sizeof(globals[init_expr->u.global_index].initial_value));
         }
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
         else if (init_expr->init_expr_type == INIT_EXPR_TYPE_REFNULL_CONST) {
             global->initial_value.u32 = (uint32)NULL_REF;
         }
@@ -1222,7 +1222,7 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
             switch (global->type) {
                 case VALUE_TYPE_I32:
                 case VALUE_TYPE_F32:
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC == 0) && (WASM_ENABLE_REF_TYPES != 0)
                 case VALUE_TYPE_FUNCREF:
                 case VALUE_TYPE_EXTERNREF:
 #endif
@@ -1236,6 +1236,12 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
                                 &global->initial_value.i64, sizeof(int64));
                     global_data += sizeof(int64);
                     break;
+#if WASM_ENABLE_GC != 0
+                case VALUE_TYPE_FUNCREF:
+                case VALUE_TYPE_EXTERNREF:
+                    /* TODO */
+                    break;
+#endif
                 default:
                     bh_assert(0);
             }
@@ -1299,7 +1305,7 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
         if (base_offset > memory_size) {
             LOG_DEBUG("base_offset(%d) > memory_size(%d)", base_offset,
                       memory_size);
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
             set_error_buf(error_buf, error_buf_size,
                           "out of bounds memory access");
 #else
@@ -1314,7 +1320,7 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
         if (base_offset + length > memory_size) {
             LOG_DEBUG("base_offset(%d) + length(%d) > memory_size(%d)",
                       base_offset, length, memory_size);
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
             set_error_buf(error_buf, error_buf_size,
                           "out of bounds memory access");
 #else
@@ -1341,7 +1347,7 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
         WASMTableInstance *table = module_inst->tables[table_seg->table_index];
         bh_assert(table);
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
         if (table->elem_type != VALUE_TYPE_FUNCREF
             && table->elem_type != VALUE_TYPE_EXTERNREF) {
             set_error_buf(error_buf, error_buf_size,
@@ -1358,7 +1364,7 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
 #endif
         bh_assert(table_data);
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
         if (!wasm_elem_is_active(table_seg->mode))
             continue;
 #endif
@@ -1368,7 +1374,7 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
             table_seg->base_offset.init_expr_type == INIT_EXPR_TYPE_I32_CONST
             || table_seg->base_offset.init_expr_type
                    == INIT_EXPR_TYPE_GET_GLOBAL
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
             || table_seg->base_offset.init_expr_type
                    == INIT_EXPR_TYPE_FUNCREF_CONST
             || table_seg->base_offset.init_expr_type
@@ -1401,7 +1407,7 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
         if ((uint32)table_seg->base_offset.u.i32 > table->cur_size) {
             LOG_DEBUG("base_offset(%d) > table->cur_size(%d)",
                       table_seg->base_offset.u.i32, table->cur_size);
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
             set_error_buf(error_buf, error_buf_size,
                           "out of bounds table access");
 #else
@@ -1416,7 +1422,7 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
         if ((uint32)table_seg->base_offset.u.i32 + length > table->cur_size) {
             LOG_DEBUG("base_offset(%d) + length(%d)> table->cur_size(%d)",
                       table_seg->base_offset.u.i32, length, table->cur_size);
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
             set_error_buf(error_buf, error_buf_size,
                           "out of bounds table access");
 #else
@@ -1561,7 +1567,7 @@ wasm_deinstantiate(WASMModuleInstance *module_inst, bool is_sub_inst)
     if (module_inst->global_data)
         wasm_runtime_free(module_inst->global_data);
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC == 0) && (WASM_ENABLE_REF_TYPES != 0)
     wasm_externref_cleanup((WASMModuleInstanceCommon *)module_inst);
 #endif
 
@@ -1683,13 +1689,13 @@ wasm_create_exec_env_and_call_function(WASMModuleInstance *module_inst,
     }
 #endif
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC == 0) && (WASM_ENABLE_REF_TYPES != 0)
     wasm_runtime_prepare_call_function(exec_env, func);
 #endif
 
     ret = wasm_call_function(exec_env, func, argc, argv);
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC == 0) && (WASM_ENABLE_REF_TYPES != 0)
     wasm_runtime_finalize_call_function(exec_env, func, ret, argv);
 #endif
 
@@ -2132,7 +2138,7 @@ wasm_enlarge_memory(WASMModuleInstance *module, uint32 inc_page_count)
     return ret;
 }
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
 bool
 wasm_enlarge_table(WASMModuleInstance *module_inst, uint32 table_idx,
                    uint32 inc_entries, uint32 init_val)
@@ -2170,7 +2176,7 @@ wasm_enlarge_table(WASMModuleInstance *module_inst, uint32 table_idx,
     table_inst->cur_size = entry_count;
     return true;
 }
-#endif /* WASM_ENABLE_REF_TYPES != 0 */
+#endif /* (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0) */
 
 bool
 wasm_call_indirect(WASMExecEnv *exec_env, uint32_t tbl_idx,

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -395,7 +395,7 @@ void
 wasm_get_module_inst_mem_consumption(const WASMModuleInstance *module,
                                      WASMModuleInstMemConsumption *mem_conspn);
 
-#if WASM_ENABLE_REF_TYPES != 0
+#if (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0)
 static inline bool
 wasm_elem_is_active(uint32 mode)
 {
@@ -417,7 +417,7 @@ wasm_elem_is_declarative(uint32 mode)
 bool
 wasm_enlarge_table(WASMModuleInstance *module_inst, uint32 table_idx,
                    uint32 inc_entries, uint32 init_val);
-#endif /* WASM_ENABLE_REF_TYPES != 0 */
+#endif /* (WASM_ENABLE_GC != 0) || (WASM_ENABLE_REF_TYPES != 0) */
 
 static inline WASMTableInstance *
 wasm_get_table_inst(const WASMModuleInstance *module_inst, const uint32 tbl_idx)


### PR DESCRIPTION
Implement loading ref type of global and table
Add macro controls of ENABLE_GC/ENABLE_REF_TYPES to explicitly distinguish
the code piece's belonging, to GC, to REF_TYPEs for to both.
Change ref_type field of ArrayType to pointer to save memory.
Fix bug of is_subtype_of check of ref types.