### PR TITLE
Fix win32 aot endian and machine type check errors (#855)

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -166,6 +166,7 @@ GET_U64_FROM_ADDR(uint32 *addr)
 #define BIN_TYPE_ELF32B 1 /* 32-bit big endian */
 #define BIN_TYPE_ELF64L 2 /* 64-bit little endian */
 #define BIN_TYPE_ELF64B 3 /* 64-bit big endian */
+#define BIN_TYPE_COFF32 4 /* 32-bit little endian */
 #define BIN_TYPE_COFF64 6 /* 64-bit little endian */
 
 /* Legal values for e_type (object file type). */
@@ -188,7 +189,8 @@ GET_U64_FROM_ADDR(uint32 *addr)
 #define E_MACHINE_ARC_COMPACT2 195  /* Synopsys ARCompact V2 */
 #define E_MACHINE_XTENSA 94         /* Tensilica Xtensa Architecture */
 #define E_MACHINE_RISCV 243         /* RISC-V 32/64 */
-#define E_MACHINE_WIN_X86_64 0x8664 /* Windowx x86-64 architecture */
+#define E_MACHINE_WIN_I386 0x14c    /* Windows i386 architecture */
+#define E_MACHINE_WIN_X86_64 0x8664 /* Windows x86-64 architecture */
 
 /* Legal values for e_version */
 #define E_VERSION_CURRENT 1 /* Current version */
@@ -317,6 +319,7 @@ get_aot_file_target(AOTTargetInfo *target_info, char *target_buf,
             machine_type = "x86_64";
             break;
         case E_MACHINE_386:
+        case E_MACHINE_WIN_I386:
             machine_type = "i386";
             break;
         case E_MACHINE_ARM:

--- a/core/iwasm/compilation/aot_emit_aot_file.c
+++ b/core/iwasm/compilation/aot_emit_aot_file.c
@@ -1913,7 +1913,8 @@ struct coff_hdr {
 #define IMAGE_FILE_MACHINE_I386 0x014c
 #define IMAGE_FILE_MACHINE_IA64 0x0200
 
-#define AOT_COFF_BIN_TYPE 6
+#define AOT_COFF32_BIN_TYPE 4 /* 32-bit little endian */
+#define AOT_COFF64_BIN_TYPE 6 /* 64-bit little endian */
 
 #define EI_NIDENT 16
 
@@ -2029,8 +2030,11 @@ aot_resolve_target_info(AOTCompContext *comp_ctx, AOTObjectData *obj_data)
         obj_data->target_info.e_version = 1;
         obj_data->target_info.e_flags = 0;
 
-        if (coff_header->u16Machine == IMAGE_FILE_MACHINE_AMD64)
-            obj_data->target_info.bin_type = AOT_COFF_BIN_TYPE;
+        if (coff_header->u16Machine == IMAGE_FILE_MACHINE_AMD64
+            || coff_header->u16Machine == IMAGE_FILE_MACHINE_IA64)
+            obj_data->target_info.bin_type = AOT_COFF64_BIN_TYPE;
+        else if (coff_header->u16Machine == IMAGE_FILE_MACHINE_I386)
+            obj_data->target_info.bin_type = AOT_COFF32_BIN_TYPE;
     }
     else if (bin_type == LLVMBinaryTypeELF32L
              || bin_type == LLVMBinaryTypeELF32B) {


### PR DESCRIPTION
Emit the correct binary type and machine type in AOT file
for win64/win32 system, and handle them in aot loader.