### PR TITLE
Implement relocation R_AARCH64_JUMP26 for aarch64 (#873)

### DIFF
--- a/core/iwasm/aot/arch/aot_reloc_aarch64.c
+++ b/core/iwasm/aot/arch/aot_reloc_aarch64.c
@@ -143,6 +143,7 @@ apply_relocation(AOTModule *module, uint8 *target_section_addr,
 {
     switch (reloc_type) {
         case R_AARCH64_CALL26:
+        case R_AARCH64_JUMP26:
         {
             void *S, *P = (void *)(target_section_addr + reloc_offset);
             int64 X, A, initial_addend;


### PR DESCRIPTION
Treat R_AARCH64_JUMP26 same as R_AARCH64_CALL26, both of their
relocation operation is S + A - P, the difference is that one is for call
(BL) instructions, the other is for jump (B) instructions.