### PR TITLE
Implement GetCurrentThreadStackLimits() for Windows 7 (#914)

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -3114,7 +3114,7 @@ aot_unload(AOTModule *module)
         wasm_runtime_free(module->aux_func_indexes);
     }
     if (module->aux_func_names) {
-        wasm_runtime_free(module->aux_func_names);
+        wasm_runtime_free((void *)module->aux_func_names);
     }
 #endif
 

--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -459,8 +459,6 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
             }
             case WASM_OP_REF_FUNC:
             {
-                uint32 func_idx;
-
                 if (!comp_ctx->enable_ref_types) {
                     goto unsupport_ref_types;
                 }

--- a/core/shared/platform/windows/platform_internal.h
+++ b/core/shared/platform/windows/platform_internal.h
@@ -25,9 +25,9 @@
 #include <stdint.h>
 #include <malloc.h>
 #include <process.h>
+#include <winsock2.h>
 #include <Windows.h>
 #include <BaseTsd.h>
-#include <winsock2.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
And fix compilation error of when build wamrc, fix compilation warnings