### PR TITLE
Fix some issues on MacOS platform (#937)

### DIFF
--- a/core/iwasm/compilation/aot_llvm.c
+++ b/core/iwasm/compilation/aot_llvm.c
@@ -1610,7 +1610,74 @@ aot_create_comp_context(AOTCompData *comp_data, aot_comp_option_t option)
                 abi = "ilp32d";
         }
 
-        if (arch) {
+#if defined(__APPLE__) || defined(__MACH__)
+        if (!abi) {
+            /* On MacOS platform, set abi to "gnu" to avoid generating
+               object file of Mach-O binary format which is unsupported */
+            abi = "gnu";
+            if (!arch && !cpu && !features) {
+                /* Get CPU name of the host machine to avoid checking
+                   SIMD capability failed */
+                if (!(cpu = cpu_new = LLVMGetHostCPUName())) {
+                    aot_set_last_error("llvm get host cpu name failed.");
+                    goto fail;
+                }
+            }
+        }
+#endif
+
+        if (abi) {
+            /* Construct target triple: <arch>-<vendor>-<sys>-<abi> */
+            const char *vendor_sys;
+            char *arch1 = arch, default_arch[32] = { 0 };
+
+            if (!arch1) {
+                char *default_triple = LLVMGetDefaultTargetTriple();
+
+                if (!default_triple) {
+                    aot_set_last_error(
+                        "llvm get default target triple failed.");
+                    goto fail;
+                }
+
+                vendor_sys = strstr(default_triple, "-");
+                bh_assert(vendor_sys);
+                bh_memcpy_s(default_arch, sizeof(default_arch), default_triple,
+                            vendor_sys - default_triple);
+                arch1 = default_arch;
+
+                LLVMDisposeMessage(default_triple);
+            }
+
+            /**
+             * Set <vendor>-<sys> according to abi to generate the object file
+             * with the correct file format which might be different from the
+             * default object file format of the host, e.g., generating AOT file
+             * for Windows/MacOS under Linux host, or generating AOT file for
+             * Linux/MacOS under Windows host.
+             */
+            if (!strcmp(abi, "msvc")) {
+                if (!strcmp(arch1, "i386"))
+                    vendor_sys = "-pc-win32-";
+                else
+                    vendor_sys = "-pc-windows-";
+            }
+            else {
+                vendor_sys = "-pc-linux-";
+            }
+
+            bh_assert(strlen(arch1) + strlen(vendor_sys) + strlen(abi)
+                      < sizeof(triple_buf));
+            bh_memcpy_s(triple_buf, sizeof(triple_buf), arch1, strlen(arch1));
+            bh_memcpy_s(triple_buf + strlen(arch1),
+                        sizeof(triple_buf) - strlen(arch1), vendor_sys,
+                        strlen(vendor_sys));
+            bh_memcpy_s(triple_buf + strlen(arch1) + strlen(vendor_sys),
+                        sizeof(triple_buf) - strlen(arch1) - strlen(vendor_sys),
+                        abi, strlen(abi));
+            triple = triple_buf;
+        }
+        else if (arch) {
             /* Construct target triple: <arch>-<vendor>-<sys>-<abi> */
             const char *vendor_sys;
             char *default_triple = LLVMGetDefaultTargetTriple();
@@ -1640,10 +1707,13 @@ aot_create_comp_context(AOTCompData *comp_data, aot_comp_option_t option)
 
             bh_assert(strlen(arch) + strlen(vendor_sys) + strlen(abi)
                       < sizeof(triple_buf));
-            memcpy(triple_buf, arch, strlen(arch));
-            memcpy(triple_buf + strlen(arch), vendor_sys, strlen(vendor_sys));
-            memcpy(triple_buf + strlen(arch) + strlen(vendor_sys), abi,
-                   strlen(abi));
+            bh_memcpy_s(triple_buf, sizeof(triple_buf), arch, strlen(arch));
+            bh_memcpy_s(triple_buf + strlen(arch),
+                        sizeof(triple_buf) - strlen(arch), vendor_sys,
+                        strlen(vendor_sys));
+            bh_memcpy_s(triple_buf + strlen(arch) + strlen(vendor_sys),
+                        sizeof(triple_buf) - strlen(arch) - strlen(vendor_sys),
+                        abi, strlen(abi));
             triple = triple_buf;
         }
 

--- a/core/shared/platform/common/posix/posix_memmap.c
+++ b/core/shared/platform/common/posix/posix_memmap.c
@@ -16,6 +16,7 @@ static size_t total_size_munmapped = 0;
 
 #define HUGE_PAGE_SIZE (2 * 1024 * 1024)
 
+#if !defined(__APPLE__) && !defined(__NuttX__)
 static inline uintptr_t
 round_up(uintptr_t v, uintptr_t b)
 {
@@ -29,6 +30,7 @@ round_down(uintptr_t v, uintptr_t b)
     uintptr_t m = b - 1;
     return v & ~m;
 }
+#endif
 
 void *
 os_mmap(void *hint, size_t size, int prot, int flags)

--- a/product-mini/platforms/darwin/CMakeLists.txt
+++ b/product-mini/platforms/darwin/CMakeLists.txt
@@ -55,8 +55,8 @@ if (NOT DEFINED WAMR_BUILD_LIBC_BUILTIN)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_LIBC_WASI)
-  # Disable libc wasi support by default
-  set (WAMR_BUILD_LIBC_WASI 0)
+  # Enable libc wasi support by default
+  set (WAMR_BUILD_LIBC_WASI 1)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_FAST_INTERP)
@@ -65,7 +65,7 @@ if (NOT DEFINED WAMR_BUILD_FAST_INTERP)
 endif ()
 
 if (NOT DEFINED WAMR_BUILD_MULTI_MODULE)
-  # Enable multiple modules
+  # Disable multiple module by default
   set (WAMR_BUILD_MULTI_MODULE 0)
 endif ()
 

--- a/tests/wamr-test-suites/spec-test-script/all.py
+++ b/tests/wamr-test-suites/spec-test-script/all.py
@@ -21,7 +21,8 @@ import time
 The script itself has to be put under the same directory with the "spec".
 """
 
-IWASM_CMD = "../../../product-mini/platforms/linux/build/iwasm"
+PLATFORM_NAME = os.uname().sysname.lower()
+IWASM_CMD = "../../../product-mini/platforms/" + PLATFORM_NAME + "/build/iwasm"
 IWASM_SGX_CMD = "../../../product-mini/platforms/linux-sgx/enclave-sample/iwasm"
 SPEC_TEST_DIR = "spec/test/core"
 WAST2WASM_CMD = "./wabt/out/gcc/Release/wat2wasm"

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -141,6 +141,8 @@ class Runner():
                 os.killpg(self.p.pid, signal.SIGTERM)
             except OSError:
                 pass
+            except IOError:
+                pass
             self.p = None
             self.stdin.close()
             if self.stdin != self.stdout:


### PR DESCRIPTION
Fix some issues on MacOS platform
- Enable libc-wasi by default
- Set target abi to "gnu" if it is not set for wamrc to avoid generating
  object file of unsupported Mach-O format
- Set `<vendor>-<sys>` info according to target abi for wamrc to support
  generating AOT file for other OSs but not current host
- Set cpu name if arch/abi/cpu are not set to avoid checking SIMD
  capability failed
- Set size level to 1 for MacOS/Windows platform to avoid relocation type
  unsupported warning
- Clear posix_memmap.c compiling warning
- Fix spec case test script issues, enable test spec cases on MacOS

Signed-off-by: Wenyong Huang <wenyong.huang@intel.com>