### PR TITLE
Refine is_xip_file and pointer range check (#965)

### DIFF
--- a/core/iwasm/aot/aot_loader.c
+++ b/core/iwasm/aot/aot_loader.c
@@ -90,7 +90,8 @@ static bool
 check_buf(const uint8 *buf, const uint8 *buf_end, uint32 length,
           char *error_buf, uint32 error_buf_size)
 {
-    if (buf + length < buf || buf + length > buf_end) {
+    if ((uintptr_t)buf + length < (uintptr_t)buf
+        || (uintptr_t)buf + length > (uintptr_t)buf_end) {
         set_error_buf(error_buf, error_buf_size, "unexpect end");
         return false;
     }

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -305,10 +305,11 @@ align_ptr(const uint8 *p, uint32 b)
     return (uint8 *)((v + m) & ~m);
 }
 
-#define CHECK_BUF(buf, buf_end, length)                   \
-    do {                                                  \
-        if (buf + length < buf || buf + length > buf_end) \
-            return false;                                 \
+#define CHECK_BUF(buf, buf_end, length)                      \
+    do {                                                     \
+        if ((uintptr_t)buf + length < (uintptr_t)buf         \
+            || (uintptr_t)buf + length > (uintptr_t)buf_end) \
+            return false;                                    \
     } while (0)
 
 #define read_uint16(p, p_end, res)                 \
@@ -347,9 +348,7 @@ wasm_runtime_is_xip_file(const uint8 *buf, uint32 size)
         if (section_type == AOT_SECTION_TYPE_TARGET_INFO) {
             p += 4;
             read_uint16(p, p_end, e_type);
-            if (e_type == E_TYPE_XIP) {
-                return true;
-            }
+            return (e_type == E_TYPE_XIP) ? true : false;
         }
         else if (section_type >= AOT_SECTION_TYPE_SIGANATURE) {
             return false;

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -47,7 +47,8 @@ static bool
 check_buf(const uint8 *buf, const uint8 *buf_end, uint32 length,
           char *error_buf, uint32 error_buf_size)
 {
-    if (buf + length < buf || buf + length > buf_end) {
+    if ((uintptr_t)buf + length < (uintptr_t)buf
+        || (uintptr_t)buf + length > (uintptr_t)buf_end) {
         set_error_buf(error_buf, error_buf_size,
                       "unexpected end of section or function");
         return false;
@@ -59,7 +60,8 @@ static bool
 check_buf1(const uint8 *buf, const uint8 *buf_end, uint32 length,
            char *error_buf, uint32 error_buf_size)
 {
-    if (buf + length < buf || buf + length > buf_end) {
+    if ((uintptr_t)buf + length < (uintptr_t)buf
+        || (uintptr_t)buf + length > (uintptr_t)buf_end) {
         set_error_buf(error_buf, error_buf_size, "unexpected end");
         return false;
     }

--- a/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.cpp
+++ b/product-mini/platforms/linux-sgx/enclave-sample/Enclave/Enclave.cpp
@@ -131,10 +131,11 @@ align_ptr(const uint8 *p, uint32 b)
 #define AOT_SECTION_TYPE_SIGANATURE 6
 #define E_TYPE_XIP 4
 
-#define CHECK_BUF(buf, buf_end, length)                   \
-    do {                                                  \
-        if (buf + length < buf || buf + length > buf_end) \
-            return false;                                 \
+#define CHECK_BUF(buf, buf_end, length)                      \
+    do {                                                     \
+        if ((uintptr_t)buf + length < (uintptr_t)buf         \
+            || (uintptr_t)buf + length > (uintptr_t)buf_end) \
+            return false;                                    \
     } while (0)
 
 #define read_uint16(p, p_end, res)                 \
@@ -162,6 +163,7 @@ is_xip_file(const uint8 *buf, uint32 size)
 
     if (get_package_type(buf, size) != Wasm_Module_AoT)
         return false;
+
     CHECK_BUF(p, p_end, 8);
     p += 8;
     while (p < p_end) {
@@ -172,15 +174,14 @@ is_xip_file(const uint8 *buf, uint32 size)
         if (section_type == AOT_SECTION_TYPE_TARGET_INFO) {
             p += 4;
             read_uint16(p, p_end, e_type);
-            if (e_type == E_TYPE_XIP) {
-                return true;
-            }
+            return (e_type == E_TYPE_XIP) ? true : false;
         }
         else if (section_type >= AOT_SECTION_TYPE_SIGANATURE) {
             return false;
         }
         p += section_size;
     }
+
     return false;
 }
 


### PR DESCRIPTION
Refine is_xip_file check, when e_type isn't E_TYPE_XIP, just return false
and no need to go through all the other sections of the AOT file.

Refine pointer range check, convert pointer to uintptr_t type before
comparison to yield possible sanitizer pointer overflow error.