### PR TITLE
Implement GC bytecode validation (#918)

### DIFF
--- a/core/config.h
+++ b/core/config.h
@@ -361,4 +361,7 @@
 #define GC_REFTYPE_MAP_SIZE_DEFAULT 64
 #endif
 
+#ifndef GC_RTTOBJ_MAP_SIZE_DEFAULT
+#define GC_RTTOBJ_MAP_SIZE_DEFAULT 64
+#endif
 #endif /* end of _CONFIG_H_ */

--- a/core/iwasm/common/gc/gc_object.c
+++ b/core/iwasm/common/gc/gc_object.c
@@ -4,3 +4,196 @@
  */
 
 #include "gc_object.h"
+
+static uint32
+rtt_obj_hash(const void *key)
+{
+    const WASMRttObjectRef rtt_obj = (const WASMRttObjectRef)key;
+
+    return (uint32)(((uintptr_t)rtt_obj->defined_type)
+                    ^ ((uintptr_t)rtt_obj->parent));
+}
+
+static bool
+rtt_obj_equal(void *key1, void *key2)
+{
+    const WASMRttObjectRef rtt_obj1 = (const WASMRttObjectRef)key1;
+    const WASMRttObjectRef rtt_obj2 = (const WASMRttObjectRef)key2;
+
+    return (rtt_obj1->defined_type == rtt_obj2->defined_type
+            && rtt_obj1->parent == rtt_obj2->parent)
+               ? true
+               : false;
+}
+
+HashMap *
+wasm_rttobj_set_create(uint32 size)
+{
+    HashMap *rtt_obj_set = bh_hash_map_create(
+        size, true, rtt_obj_hash, rtt_obj_equal, NULL, wasm_runtime_free);
+
+    return rtt_obj_set;
+}
+
+WASMRttObjectRef
+wasm_rtt_obj_new(HashMap *rtt_obj_set, WASMRttObject *parent,
+                 WASMType *defined_type, uint32 defined_type_idx)
+{
+    WASMRttObject *rtt_obj, *rtt_obj_ret;
+
+    if (!(rtt_obj = wasm_runtime_malloc(sizeof(WASMRttObject))))
+        return NULL;
+
+    rtt_obj->header = WASM_OBJ_RTT_OBJ_FLAG;
+    rtt_obj->type_flag = defined_type->type_flag;
+    rtt_obj->n = parent ? parent->n + 1 : 0;
+    rtt_obj->defined_type_idx = defined_type_idx;
+    rtt_obj->defined_type = defined_type;
+    rtt_obj->root = parent ? parent->root : rtt_obj;
+    rtt_obj->parent = parent;
+
+    if ((rtt_obj_ret = bh_hash_map_find(rtt_obj_set, (void *)rtt_obj))) {
+        wasm_runtime_free(rtt_obj);
+        return rtt_obj_ret;
+    }
+
+    if (!bh_hash_map_insert(rtt_obj_set, rtt_obj, rtt_obj)) {
+        wasm_runtime_free(rtt_obj);
+        return NULL;
+    }
+
+    return rtt_obj;
+}
+
+static void *
+gc_obj_malloc(void *heap_handle, uint64 size)
+{
+    void *mem;
+
+    /* Allocate from global heap for test,
+       TODO: changed to allocate from heap_handle */
+    if (size >= UINT32_MAX || !(mem = wasm_runtime_malloc((uint32)size))) {
+        return NULL;
+    }
+
+    memset(mem, 0, (uint32)size);
+    return mem;
+}
+
+WASMStructObjectRef
+wasm_struct_obj_new(void *heap_handle, WASMRttObjectRef rtt_obj)
+{
+    WASMStructObjectRef struct_obj;
+    WASMStructType *struct_type;
+
+    bh_assert(rtt_obj->type_flag == WASM_TYPE_STRUCT);
+
+    struct_type = (WASMStructType *)rtt_obj->defined_type;
+    if (!(struct_obj = gc_obj_malloc(heap_handle, struct_type->total_size))) {
+        return NULL;
+    }
+
+    struct_obj->header = (WASMObjectHeader)rtt_obj;
+    return struct_obj;
+}
+
+void
+wasm_struct_obj_set_field(WASMStructObjectRef struct_obj, uint32 field_idx,
+                          WASMValue *value)
+{}
+
+WASMValue *
+wasm_struct_obj_get_field(const WASMStructObjectRef struct_obj,
+                          uint32 field_idx)
+{
+    return NULL;
+}
+
+WASMArrayObjectRef
+wasm_array_obj_new(void *heap_handle, WASMRttObjectRef rtt_obj, uint32 length,
+                   WASMValue *init_value)
+{
+    WASMArrayObjectRef array_obj;
+    WASMArrayType *array_type;
+    uint64 total_size;
+    uint32 elem_size, elem_size_log;
+
+    bh_assert(rtt_obj->type_flag == WASM_TYPE_ARRAY);
+
+    if (length >= (1 << 29))
+        return NULL;
+
+    array_type = (WASMArrayType *)rtt_obj->defined_type;
+    if (array_type->elem_type == PACKED_TYPE_I8) {
+        elem_size = 1;
+        elem_size_log = 0;
+    }
+    else if (array_type->elem_type == PACKED_TYPE_I16) {
+        elem_size = 2;
+        elem_size_log = 1;
+    }
+    else {
+        elem_size = wasm_value_type_size(array_type->elem_type);
+        elem_size_log = (elem_size == 4) ? 2 : 3;
+    }
+
+    total_size =
+        offsetof(WASMArrayObject, elem_data) + (uint64)elem_size * length;
+    if (!(array_obj = gc_obj_malloc(heap_handle, total_size))) {
+        return NULL;
+    }
+
+    array_obj->header = (WASMObjectHeader)rtt_obj;
+    array_obj->length = (length << 2) | elem_size_log;
+    return array_obj;
+}
+
+void
+wasm_array_obj_set_elem(WASMArrayObjectRef array_obj, uint32 elem_idx,
+                        WASMValue *value)
+{}
+
+WASMValue *
+wasm_array_obj_get_elem(WASMArrayObjectRef array_obj, uint32 elem_idx)
+{
+    return NULL;
+}
+
+WASMFuncObjectRef
+wasm_func_obj_new(void *heap_handle, WASMRttObjectRef rtt_obj, uint32 func_idx)
+{
+    WASMFuncObjectRef func_obj;
+    WASMFuncType *func_type;
+    uint64 total_size;
+
+    bh_assert(rtt_obj->type_flag == WASM_TYPE_FUNC);
+
+    func_type = (WASMFuncType *)rtt_obj->defined_type;
+
+    total_size =
+        offsetof(WASMFuncObject, param_data) + func_type->total_param_size;
+    if (!(func_obj = gc_obj_malloc(heap_handle, total_size))) {
+        return NULL;
+    }
+
+    func_obj->header = (WASMObjectHeader)rtt_obj;
+    func_obj->func_idx = func_idx;
+    return func_obj;
+}
+
+void
+wasm_func_obj_set_param(WASMFuncObjectRef func_obj, uint32 param_idx,
+                        WASMValue *value)
+{}
+
+WASMValue *
+wasm_func_obj_get_param(const WASMFuncObjectRef func_obj, uint32 param_idx)
+{
+    return NULL;
+}
+
+bool
+wasm_obj_is_subtype_of(WASMObjectRef obj1, WASMObjectRef obj2)
+{
+    return false;
+}

--- a/core/iwasm/common/gc/gc_object.h
+++ b/core/iwasm/common/gc/gc_object.h
@@ -13,56 +13,318 @@ extern "C" {
 #endif
 
 /**
- * Object header of a WASM object, can be a pointer of
- * defined type (WASMFuncType/WASMStructType or WASMArrayType),
- * or rtt type (WASMRttObject),
- * or ExternRef type (bit_1 = 1).
- * And use bit_0 to mark whether it is an weakref object.
+ * Object header of a WASM object, as the adddress of allocated memory
+ * must be 8-byte aligned, the lowest 3 bits are zero, we use them to
+ * mark the object:
+ *   bits[0] is 1: the object is weak referenced
+ *   bits[1] is 1: it is an rtt object
+ *   bits[2] is 1: it is an externref object
+ *   if both bits[1] and bits[2] are 0, then this object header must
+ *   be a pointer of a WASMRttObject, denotes that the object is a
+ *   struct object, or an array object, or a function object
  */
 typedef uintptr_t WASMObjectHeader;
 
-/* Representation of WASM objects. */
+#define WASM_OBJ_HEADER_MASK (~((uintptr_t)7))
+
+#define WASM_OBJ_WEAK_REF_FLAG (((uintptr_t)1) << 0)
+
+#define WASM_OBJ_RTT_OBJ_FLAG (((uintptr_t)1) << 1)
+
+#define WASM_OBJ_EXTERNREF_OBJ_FLAG (((uintptr_t)1) << 2)
+
+/* Representation of WASM objects */
 typedef struct WASMObject {
     WASMObjectHeader header;
 } WASMObject, *WASMObjectRef;
 
-/* Representation of WASM struct objects. */
-typedef struct WASMStructObject {
-    WASMObject super_;
-} WASMStructObject;
+/* Representation of WASM rtt objects */
+typedef struct WASMRttObject {
+    /* bits[1] must be 1, denotes an rtt object */
+    WASMObjectHeader header;
+    /* type_flag must be WASM_TYPE_FUNC/STRUCT/ARRAY to
+       denote an object of func, struct or array */
+    uint16 type_flag;
+    /* The inheritance depth */
+    uint16 n;
+    uint32 defined_type_idx;
+    WASMType *defined_type;
+    /* The root of the super rtt objects, whose parent is NULL */
+    struct WASMRttObject *root;
+    struct WASMRttObject *parent;
+} WASMRttObject, *WASMRttObjectRef;
 
-/* Representation of WASM array objects. */
+/* Representation of WASM externref objects */
+typedef struct WASMExternrefObject {
+    /* bits[2] must be 1, denotes an externref object */
+    WASMObjectHeader header;
+    /* The externref pointer passed from host */
+    void *externref;
+} WASMExternrefObject, *WASMExternrefObjectRef;
+
+/**
+ * Representation of WASM i31 objects, the lowest bit is 1:
+ * for a pointer of WASMObject, if the lowest bit is 1, then it is an
+ * i31 object and bits[1..31] stores the actual i31 value, otherwise
+ * it is a normal object of rtt/externref/struct/array/func */
+typedef uintptr_t WASMI31ObjectRef;
+
+/* Representation of WASM struct objects */
+typedef struct WASMStructObject {
+    /* Must be pointer of WASMRttObject of struct type */
+    WASMObjectHeader header;
+    uint8 field_data[1];
+} WASMStructObject, *WASMStructObjectRef;
+
+/* Representation of WASM array objects */
 typedef struct WASMArrayObject {
-    WASMObject super_;
+    /* Must be pointer of WASMRttObject of array type */
+    WASMObjectHeader header;
     /* (<array length> << 2) | <array element size>,
-     * actual_length = lenght >> 2
+     * elem_count = lenght >> 2
      * elem_size = 2 ^ (length & 0x3)
      */
     uint32 length;
-} WASMArrayObject;
+    uint8 elem_data[1];
+} WASMArrayObject, *WASMArrayObjectRef;
 
-/* Representation of WASM function objects. */
+#define WASM_ARRAY_LENGTH_SHIFT 2
+#define WASM_ARRAY_ELEM_SIZE_MASK 3
+
+/* Representation of WASM function objects */
 typedef struct WASMFuncObject {
-    WASMObject super_;
-} WASMFuncObject;
+    /* must be pointer of WASMRttObject of array type */
+    WASMObjectHeader header;
+    uint32 func_idx;
+    uint8 *param_data[1];
+} WASMFuncObject, *WASMFuncObjectRef;
 
-/* Representation of WASM externref objects. */
-typedef struct WASMExternrefObject {
-    WASMObject super_;
-} WASMExternrefObject;
+inline static WASMObjectHeader
+wasm_object_header(const WASMObjectRef obj)
+{
+    return (obj->header & WASM_OBJ_HEADER_MASK);
+}
 
-/* Representation of WASM rtt objects. */
-typedef struct WASMRttObject {
-    /* type must be 2, denotes an Rtt object */
-    uintptr_t type;
-    /* 0/1/2 means it is rtt object of
-      func/struct/array type */
-    uint16 flag;
-    uint16 n;
-    WASMType *defined_type;
-    struct WASMRttObject *root;
-    struct WASMRttObject *parent;
-} WASMRttObject;
+HashMap *
+wasm_rttobj_set_create(uint32 size);
+
+WASMRttObjectRef
+wasm_rtt_obj_new(HashMap *rtt_obj_set, WASMRttObject *parent,
+                 WASMType *defined_type, uint32 defined_type_idx);
+
+inline static WASMRttObjectRef
+wasm_rtt_obj_get_parent(const WASMRttObjectRef rtt_obj)
+{
+    return rtt_obj->parent;
+}
+
+inline static WASMType *
+wasm_rtt_obj_get_defined_type(const WASMRttObjectRef rtt_obj)
+{
+    return rtt_obj->defined_type;
+}
+
+inline static uint32
+wasm_rtt_obj_get_defined_type_idx(const WASMRttObjectRef rtt_obj)
+{
+    return rtt_obj->defined_type_idx;
+}
+
+inline static uint32
+wasm_rtt_obj_get_inherit_depth(const WASMRttObjectRef rtt_obj)
+{
+    return rtt_obj->n;
+}
+
+WASMStructObjectRef
+wasm_struct_obj_new(void *heap_handle, WASMRttObjectRef rtt_obj);
+
+void
+wasm_struct_obj_set_field(WASMStructObjectRef struct_obj, uint32 field_idx,
+                          WASMValue *value);
+
+WASMValue *
+wasm_struct_obj_get_field(const WASMStructObjectRef struct_obj,
+                          uint32 field_idx);
+
+WASMArrayObjectRef
+wasm_array_obj_new(void *heap_handle, WASMRttObjectRef rtt_obj, uint32 length,
+                   WASMValue *init_value);
+
+void
+wasm_array_obj_set_elem(WASMArrayObjectRef array_obj, uint32 elem_idx,
+                        WASMValue *value);
+
+WASMValue *
+wasm_array_obj_get_elem(WASMArrayObjectRef array_obj, uint32 elem_idx);
+
+/**
+ * Return the logarithm of the size of array element.
+ *
+ * @param array the WASM array object
+ *
+ * @return log(size of the array element)
+ */
+inline static uint32
+wasm_array_obj_elem_size_log(const WASMArrayObjectRef array_obj)
+{
+    return (array_obj->length & WASM_ARRAY_ELEM_SIZE_MASK);
+}
+
+/**
+ * Return the length of the array.
+ *
+ * @param array_obj the WASM array object
+ *
+ * @return the length of the array
+ */
+inline static uint32
+wasm_array_obj_length(const WASMArrayObjectRef array_obj)
+{
+    return array_obj->length >> WASM_ARRAY_LENGTH_SHIFT;
+}
+
+/**
+ * Return the address of the first element of an array object.
+ *
+ * @param array_obj the WASM array object
+ *
+ * @return the address of the first element of the array object
+ */
+inline static void *
+wasm_array_obj_first_elem_addr(const WASMArrayObjectRef array_obj)
+{
+    return array_obj->elem_data;
+}
+
+/**
+ * Return the address of the i-th element of an array object.
+ *
+ * @param array_obj the WASM array object
+ * @param index the index of the element
+ *
+ * @return the address of the i-th element of the array object
+ */
+inline static void *
+wasm_array_obj_elem_addr(const WASMArrayObjectRef array_obj, uint32 elem_idx)
+{
+    return array_obj->elem_data
+           + (elem_idx << wasm_array_obj_elem_size_log(array_obj));
+}
+
+WASMFuncObjectRef
+wasm_func_obj_new(void *heap_handle, WASMRttObjectRef rtt_obj, uint32 func_idx);
+
+void
+wasm_func_obj_set_param(WASMFuncObjectRef func_obj, uint32 param_idx,
+                        WASMValue *value);
+
+WASMValue *
+wasm_func_obj_get_param(const WASMFuncObjectRef func_obj, uint32 param_idx);
+
+WASMExternrefObjectRef
+wasm_externref_obj_new(void *heap_handle, void *externref);
+
+inline static void *
+wasm_externref_obj_get_value(const WASMExternrefObjectRef externref_obj)
+{
+    return externref_obj->externref;
+}
+
+inline WASMI31ObjectRef
+wasm_i31_obj_new(uint32 i31_value)
+{
+    return (((uintptr_t)i31_value) << 1) | 1;
+}
+
+inline uint32
+wasm_i31_obj_get_value(WASMI31ObjectRef i31_obj)
+{
+    return (uint32)(((uintptr_t)i31_obj) >> 1);
+}
+
+inline static bool
+wasm_obj_is_i31_obj(WASMObjectRef obj)
+{
+    bh_assert(obj);
+    return (((uintptr_t)obj) & 1) ? true : false;
+}
+
+inline static bool
+wasm_obj_is_rtt_obj(WASMObjectRef obj)
+{
+    bh_assert(obj);
+    return (!wasm_obj_is_i31_obj(obj) && (obj->header & WASM_OBJ_RTT_OBJ_FLAG))
+               ? true
+               : false;
+}
+
+inline static bool
+wasm_obj_is_externref_obj(WASMObjectRef obj)
+{
+    bh_assert(obj);
+    return (!wasm_obj_is_i31_obj(obj)
+            && (obj->header & WASM_OBJ_EXTERNREF_OBJ_FLAG))
+               ? true
+               : false;
+}
+
+inline static bool
+wasm_obj_is_struct_obj(WASMObjectRef obj)
+{
+    WASMRttObjectRef rtt_obj;
+
+    bh_assert(obj);
+
+    if (wasm_obj_is_i31_obj(obj)
+        || (obj->header
+            & (WASM_OBJ_RTT_OBJ_FLAG | WASM_OBJ_EXTERNREF_OBJ_FLAG)))
+        return false;
+
+    rtt_obj = (WASMRttObjectRef)wasm_object_header(obj);
+    return rtt_obj->type_flag == WASM_TYPE_STRUCT ? true : false;
+}
+
+inline static bool
+wasm_obj_is_array_obj(WASMObjectRef obj)
+{
+    WASMRttObjectRef rtt_obj;
+
+    bh_assert(obj);
+
+    if (wasm_obj_is_i31_obj(obj)
+        || (obj->header
+            & (WASM_OBJ_RTT_OBJ_FLAG | WASM_OBJ_EXTERNREF_OBJ_FLAG)))
+        return false;
+
+    rtt_obj = (WASMRttObjectRef)wasm_object_header(obj);
+    return rtt_obj->type_flag == WASM_TYPE_ARRAY ? true : false;
+}
+
+inline static bool
+wasm_obj_is_func_obj(WASMObjectRef obj)
+{
+    WASMRttObjectRef rtt_obj;
+
+    bh_assert(obj);
+
+    if (wasm_obj_is_i31_obj(obj)
+        || (obj->header
+            & (WASM_OBJ_RTT_OBJ_FLAG | WASM_OBJ_EXTERNREF_OBJ_FLAG)))
+        return false;
+
+    rtt_obj = (WASMRttObjectRef)wasm_object_header(obj);
+    return rtt_obj->type_flag == WASM_TYPE_FUNC ? true : false;
+}
+
+inline static bool
+wasm_obj_is_null_obj(WASMObjectRef obj)
+{
+    return obj == NULL ? true : false;
+}
+
+bool
+wasm_obj_is_subtype_of(WASMObjectRef obj1, WASMObjectRef obj2);
 
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/core/iwasm/common/gc/gc_type.c
+++ b/core/iwasm/common/gc/gc_type.c
@@ -33,9 +33,6 @@ wasm_dump_value_type(uint8 type, const WASMRefType *ref_type)
         case REF_TYPE_FUNCREF:
             os_printf("funcref");
             break;
-        case REF_TYPE_EXTERNREF:
-            os_printf("externref");
-            break;
         case REF_TYPE_ANYREF:
             os_printf("anyref");
             break;
@@ -53,9 +50,6 @@ wasm_dump_value_type(uint8 type, const WASMRefType *ref_type)
                     case HEAP_TYPE_FUNC:
                         os_printf("func");
                         break;
-                    case HEAP_TYPE_EXTERN:
-                        os_printf("extern");
-                        break;
                     case HEAP_TYPE_ANY:
                         os_printf("any");
                         break;
@@ -67,6 +61,9 @@ wasm_dump_value_type(uint8 type, const WASMRefType *ref_type)
                         break;
                     case HEAP_TYPE_DATA:
                         os_printf("data");
+                        break;
+                    case HEAP_TYPE_ARRAY:
+                        os_printf("array");
                         break;
                 }
             }
@@ -103,6 +100,9 @@ wasm_dump_value_type(uint8 type, const WASMRefType *ref_type)
             break;
         case REF_TYPE_DATAREF:
             os_printf("dataref");
+            break;
+        case REF_TYPE_ARRAYREF:
+            os_printf("arrayref");
             break;
         default:
             bh_assert(0);
@@ -189,8 +189,23 @@ wasm_dump_array_type(const WASMArrayType *type)
     os_printf("\n");
 }
 
-bool
-wasm_func_type_equal(const WASMFuncType *type1, const WASMFuncType *type2)
+typedef struct TypeIdxNode {
+    uint32 type_idx1;
+    uint32 type_idx2;
+    struct TypeIdxNode *next;
+} TypeIdxNode, *TypeIdxList;
+
+static bool
+wasm_reftype_equal_recursive(uint8 type1, const WASMRefType *reftype1,
+                             uint8 type2, const WASMRefType *reftype2,
+                             const WASMTypePtr *types, uint32 type_count,
+                             TypeIdxList type_idx_list);
+
+static bool
+wasm_func_type_equal_recursive(const WASMFuncType *type1,
+                               const WASMFuncType *type2,
+                               const WASMTypePtr *types, uint32 type_count,
+                               TypeIdxList type_idx_list)
 {
     uint32 i, j = 0;
 
@@ -214,8 +229,9 @@ wasm_func_type_equal(const WASMFuncType *type1, const WASMFuncType *type2)
 
             ref_type1 = type1->ref_type_maps[j].ref_type;
             ref_type2 = type2->ref_type_maps[j].ref_type;
-            if (!wasm_reftype_equal(ref_type1->ref_type, ref_type1,
-                                    ref_type2->ref_type, ref_type2))
+            if (!wasm_reftype_equal_recursive(ref_type1->ref_type, ref_type1,
+                                              ref_type2->ref_type, ref_type2,
+                                              types, type_count, type_idx_list))
                 return false;
 
             j++;
@@ -226,7 +242,18 @@ wasm_func_type_equal(const WASMFuncType *type1, const WASMFuncType *type2)
 }
 
 bool
-wasm_struct_type_equal(const WASMStructType *type1, const WASMStructType *type2)
+wasm_func_type_equal(const WASMFuncType *type1, const WASMFuncType *type2,
+                     const WASMTypePtr *types, uint32 type_count)
+{
+    return wasm_func_type_equal_recursive(type1, type2, types, type_count,
+                                          NULL);
+}
+
+static bool
+wasm_struct_type_equal_recursive(const WASMStructType *type1,
+                                 const WASMStructType *type2,
+                                 const WASMTypePtr *types, uint32 type_count,
+                                 TypeIdxList type_idx_list)
 {
     uint32 i, j = 0;
 
@@ -251,8 +278,9 @@ wasm_struct_type_equal(const WASMStructType *type1, const WASMStructType *type2)
 
             ref_type1 = type1->ref_type_maps[j].ref_type;
             ref_type2 = type2->ref_type_maps[j].ref_type;
-            if (!wasm_reftype_equal(ref_type1->ref_type, ref_type1,
-                                    ref_type2->ref_type, ref_type2))
+            if (!wasm_reftype_equal_recursive(ref_type1->ref_type, ref_type1,
+                                              ref_type2->ref_type, ref_type2,
+                                              types, type_count, type_idx_list))
                 return false;
 
             j++;
@@ -263,7 +291,18 @@ wasm_struct_type_equal(const WASMStructType *type1, const WASMStructType *type2)
 }
 
 bool
-wasm_array_type_equal(const WASMArrayType *type1, const WASMArrayType *type2)
+wasm_struct_type_equal(const WASMStructType *type1, const WASMStructType *type2,
+                       const WASMTypePtr *types, uint32 type_count)
+{
+    return wasm_struct_type_equal_recursive(type1, type2, types, type_count,
+                                            NULL);
+}
+
+static bool
+wasm_array_type_equal_recursive(const WASMArrayType *type1,
+                                const WASMArrayType *type2,
+                                const WASMTypePtr *types, uint32 type_count,
+                                TypeIdxList type_idx_list)
 {
     if (type1 == type2)
         return true;
@@ -271,15 +310,23 @@ wasm_array_type_equal(const WASMArrayType *type1, const WASMArrayType *type2)
     if (type1->elem_flags != type2->elem_flags)
         return false;
 
-    if (!wasm_reftype_equal(type1->elem_type, type1->elem_ref_type,
-                            type2->elem_type, type2->elem_ref_type))
-        return false;
-
-    return true;
+    return wasm_reftype_equal_recursive(type1->elem_type, type1->elem_ref_type,
+                                        type2->elem_type, type2->elem_ref_type,
+                                        types, type_count, type_idx_list);
 }
 
 bool
-wasm_type_equal(const WASMType *type1, const WASMType *type2)
+wasm_array_type_equal(const WASMArrayType *type1, const WASMArrayType *type2,
+                      const WASMTypePtr *types, uint32 type_count)
+{
+    return wasm_array_type_equal_recursive(type1, type2, types, type_count,
+                                           NULL);
+}
+
+static bool
+wasm_type_equal_recursive(const WASMType *type1, const WASMType *type2,
+                          const WASMTypePtr *types, uint32 type_count,
+                          TypeIdxList type_idx_list)
 {
     if (type1 == type2)
         return true;
@@ -288,23 +335,33 @@ wasm_type_equal(const WASMType *type1, const WASMType *type2)
         return false;
 
     if (wasm_type_is_func_type(type1))
-        return wasm_func_type_equal((WASMFuncType *)type1,
-                                    (WASMFuncType *)type2);
+        return wasm_func_type_equal_recursive((WASMFuncType *)type1,
+                                              (WASMFuncType *)type2, types,
+                                              type_count, type_idx_list);
     else if (wasm_type_is_struct_type(type1))
-        return wasm_struct_type_equal((WASMStructType *)type1,
-                                      (WASMStructType *)type2);
+        return wasm_struct_type_equal_recursive((WASMStructType *)type1,
+                                                (WASMStructType *)type2, types,
+                                                type_count, type_idx_list);
     else if (wasm_type_is_array_type(type1))
-        return wasm_array_type_equal((WASMArrayType *)type1,
-                                     (WASMArrayType *)type2);
+        return wasm_array_type_equal_recursive((WASMArrayType *)type1,
+                                               (WASMArrayType *)type2, types,
+                                               type_count, type_idx_list);
 
     bh_assert(0);
     return false;
 }
 
 bool
+wasm_type_equal(const WASMType *type1, const WASMType *type2,
+                const WASMTypePtr *types, uint32 type_count)
+{
+    return wasm_type_equal_recursive(type1, type2, types, type_count, NULL);
+}
+
+bool
 wasm_func_type_is_subtype_of(const WASMFuncType *type1,
-                             const WASMFuncType *type2, const WASMType **types,
-                             uint32 type_count)
+                             const WASMFuncType *type2,
+                             const WASMTypePtr *types, uint32 type_count)
 {
     /**
      * The GC proposal overview defines:
@@ -317,13 +374,57 @@ wasm_func_type_is_subtype_of(const WASMFuncType *type1,
      * But from our testing, the spec's interpreter doesn't support it yet,
      * we just check whether the two function types are the same or not.
      */
-    return wasm_func_type_equal(type1, type2);
+    return wasm_func_type_equal(type1, type2, types, type_count);
+}
+
+bool
+wasm_func_type_result_is_subtype_of(const WASMFuncType *type1,
+                                    const WASMFuncType *type2,
+                                    const WASMTypePtr *types, uint32 type_count)
+{
+    const WASMRefType *ref_type1 = NULL, *ref_type2 = NULL;
+    const WASMRefTypeMap *ref_type_map1, *ref_type_map2;
+    uint32 i;
+
+    if (type1 == type2)
+        return true;
+
+    if (type1->result_count != type2->result_count)
+        return false;
+
+    ref_type_map1 = type1->result_ref_type_maps;
+    ref_type_map2 = type2->result_ref_type_maps;
+
+    for (i = 0; i < type1->result_count; i++) {
+        ref_type1 = ref_type2 = NULL;
+        if (wasm_is_type_multi_byte_type(
+                type1->types[type1->param_count + i])) {
+            bh_assert(ref_type_map1
+                      && ref_type_map1->index == type1->param_count + i);
+            ref_type1 = ref_type_map1->ref_type;
+            ref_type_map1++;
+        }
+        if (wasm_is_type_multi_byte_type(
+                type2->types[type2->param_count + i])) {
+            bh_assert(ref_type_map2
+                      && ref_type_map2->index == type1->param_count + i);
+            ref_type2 = ref_type_map2->ref_type;
+            ref_type_map2++;
+        }
+        if (!wasm_reftype_is_subtype_of(type1->types[type1->param_count + i],
+                                        ref_type1,
+                                        type2->types[type2->param_count + i],
+                                        ref_type2, types, type_count)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 bool
 wasm_struct_type_is_subtype_of(const WASMStructType *type1,
                                const WASMStructType *type2,
-                               const WASMType **types, uint32 type_count)
+                               const WASMTypePtr *types, uint32 type_count)
 {
     const WASMRefType *ref_type1 = NULL, *ref_type2 = NULL;
     uint32 i, j1 = 0, j2 = 0;
@@ -354,7 +455,8 @@ wasm_struct_type_is_subtype_of(const WASMStructType *type1,
                 ref_type1 = type1->ref_type_maps[j1++].ref_type;
                 ref_type2 = type2->ref_type_maps[j2++].ref_type;
                 if (!wasm_reftype_equal(ref_type1->ref_type, ref_type1,
-                                        ref_type2->ref_type, ref_type2))
+                                        ref_type2->ref_type, ref_type2, types,
+                                        type_count))
                     return false;
             }
         }
@@ -377,7 +479,8 @@ wasm_struct_type_is_subtype_of(const WASMStructType *type1,
                     ref_type1 = type1->ref_type_maps[j1++].ref_type;
                     ref_type2 = type2->ref_type_maps[j2++].ref_type;
                     if (!wasm_reftype_equal(ref_type1->ref_type, ref_type1,
-                                            ref_type2->ref_type, ref_type2))
+                                            ref_type2->ref_type, ref_type2,
+                                            types, type_count))
                         return false;
                 }
             }
@@ -408,7 +511,7 @@ wasm_struct_type_is_subtype_of(const WASMStructType *type1,
 bool
 wasm_array_type_is_subtype_of(const WASMArrayType *type1,
                               const WASMArrayType *type2,
-                              const WASMType **types, uint32 type_count)
+                              const WASMTypePtr *types, uint32 type_count)
 {
     /**
      * An array type is a supertype of another array type if:
@@ -424,7 +527,8 @@ wasm_array_type_is_subtype_of(const WASMArrayType *type1,
         /* The elem is mutable in both types: the storage types
            must be the same */
         return wasm_reftype_equal(type1->elem_type, type1->elem_ref_type,
-                                  type2->elem_type, type2->elem_ref_type);
+                                  type2->elem_type, type2->elem_ref_type, types,
+                                  type_count);
     }
     else {
         /* The elem is immutable in both types: their storage types
@@ -438,7 +542,7 @@ wasm_array_type_is_subtype_of(const WASMArrayType *type1,
 
 bool
 wasm_type_is_subtype_of(const WASMType *type1, const WASMType *type2,
-                        const WASMType **types, uint32 type_count)
+                        const WASMTypePtr *types, uint32 type_count)
 {
     if (type1 == type2)
         return true;
@@ -468,7 +572,8 @@ wasm_reftype_size(uint8 type)
         return 4;
     else if (type == VALUE_TYPE_I64 || type == VALUE_TYPE_F64)
         return 8;
-    else if (type >= (uint8)REF_TYPE_DATAREF && type <= (uint8)REF_TYPE_FUNCREF)
+    else if (type >= (uint8)REF_TYPE_ARRAYREF
+             && type <= (uint8)REF_TYPE_FUNCREF)
         return sizeof(uintptr_t);
     else if (type == PACKED_TYPE_I8)
         return 1;
@@ -511,9 +616,50 @@ wasm_reftype_struct_size(const WASMRefType *ref_type)
     return 0;
 }
 
-bool
-wasm_refheaptype_equal(const RefHeapType_Common *ref_heap_type1,
-                       const RefHeapType_Common *ref_heap_type2)
+/* Recursively check whether two type indexes are equivalent, or,
+   types[type_idx1] is equivalent to types[type_idx2] */
+static bool
+type_idx_equal_recursive(uint32 type_idx1, uint32 type_idx2,
+                         const WASMTypePtr *types, uint32 type_count,
+                         TypeIdxList type_idx_list)
+{
+    TypeIdxNode type_idx_head = { 0 }, *node, *node_end;
+
+    if (type_idx1 == type_idx2)
+        return true;
+
+    if (type_idx1 >= type_count || type_idx2 >= type_count)
+        return false;
+
+    node = node_end = type_idx_list;
+    while (node) {
+        /* If the two type indexes are already in the type idx list,
+           meaning that they must be equal, or endless recursive loop
+           will occur. */
+        if ((node->type_idx1 == type_idx1 && node->type_idx2 == type_idx2)
+            || (node->type_idx1 == type_idx2 && node->type_idx2 == type_idx1))
+            return true;
+        node_end = node;
+        node = node->next;
+    }
+
+    /* Add node to type idx list */
+    type_idx_head.type_idx1 = type_idx1;
+    type_idx_head.type_idx2 = type_idx2;
+    if (!type_idx_list)
+        type_idx_list = &type_idx_head;
+    else
+        node_end->next = &type_idx_head;
+
+    return wasm_type_equal_recursive(types[type_idx1], types[type_idx2], types,
+                                     type_count, type_idx_list);
+}
+
+static bool
+wasm_refheaptype_equal_recursive(const RefHeapType_Common *ref_heap_type1,
+                                 const RefHeapType_Common *ref_heap_type2,
+                                 const WASMTypePtr *types, uint32 type_count,
+                                 TypeIdxList type_idx_list)
 {
     RefHeapType_RttN *ht_rttn1, *ht_rttn2;
     RefHeapType_Rtt *ht_rtt1, *ht_rtt2;
@@ -524,12 +670,20 @@ wasm_refheaptype_equal(const RefHeapType_Common *ref_heap_type1,
     if (ref_heap_type1->ref_type != ref_heap_type2->ref_type)
         return false;
 
-    if (ref_heap_type1->heap_type != ref_heap_type2->heap_type)
+    if (ref_heap_type1->heap_type != ref_heap_type2->heap_type) {
+        if (wasm_is_refheaptype_typeidx(ref_heap_type1)
+            && wasm_is_refheaptype_typeidx(ref_heap_type2)) {
+            return type_idx_equal_recursive(ref_heap_type1->heap_type,
+                                            ref_heap_type2->heap_type, types,
+                                            type_count, type_idx_list);
+        }
         return false;
+    }
 
     if (wasm_is_refheaptype_common(ref_heap_type1)
         || wasm_is_refheaptype_typeidx(ref_heap_type1))
-        /* No need to extra info for common types and (type i) */
+        /* No need to check extra info for common types and (type i)
+           as their heap_types are the same */
         return true;
 
     if (wasm_is_refheaptype_rttn(ref_heap_type1)) {
@@ -537,7 +691,9 @@ wasm_refheaptype_equal(const RefHeapType_Common *ref_heap_type1,
         ht_rttn2 = (RefHeapType_RttN *)ref_heap_type2;
         /* Check n and i of (rtt n i) */
         return (ht_rttn1->n == ht_rttn2->n
-                && ht_rttn1->type_idx == ht_rttn2->type_idx)
+                && type_idx_equal_recursive(ht_rttn1->type_idx,
+                                            ht_rttn2->type_idx, types,
+                                            type_count, type_idx_list))
                    ? true
                    : false;
     }
@@ -546,7 +702,8 @@ wasm_refheaptype_equal(const RefHeapType_Common *ref_heap_type1,
         ht_rtt1 = (RefHeapType_Rtt *)ref_heap_type1;
         ht_rtt2 = (RefHeapType_Rtt *)ref_heap_type2;
         /* Check i of (rtt i) */
-        return (ht_rtt1->type_idx == ht_rtt2->type_idx) ? true : false;
+        return type_idx_equal_recursive(ht_rtt1->type_idx, ht_rtt2->type_idx,
+                                        types, type_count, type_idx_list);
     }
 
     bh_assert(0);
@@ -554,32 +711,69 @@ wasm_refheaptype_equal(const RefHeapType_Common *ref_heap_type1,
 }
 
 bool
-wasm_refrttntype_equal(const RefRttNType *ref_rttn_type1,
-                       const RefRttNType *ref_rttn_type2)
+wasm_refheaptype_equal(const RefHeapType_Common *ref_heap_type1,
+                       const RefHeapType_Common *ref_heap_type2,
+                       const WASMTypePtr *types, uint32 type_count)
+{
+    return wasm_refheaptype_equal_recursive(ref_heap_type1, ref_heap_type2,
+                                            types, type_count, NULL);
+}
+
+static bool
+wasm_refrttntype_equal_recursive(const RefRttNType *ref_rttn_type1,
+                                 const RefRttNType *ref_rttn_type2,
+                                 const WASMTypePtr *types, uint32 type_count,
+                                 TypeIdxList type_idx_list)
 {
     return (ref_rttn_type1->n == ref_rttn_type2->n
-            && ref_rttn_type1->type_idx == ref_rttn_type2->type_idx)
+            && type_idx_equal_recursive(ref_rttn_type1->type_idx,
+                                        ref_rttn_type2->type_idx, types,
+                                        type_count, type_idx_list))
                ? true
                : false;
 }
 
 bool
-wasm_refrtttype_equal(const RefRttType *ref_rtt_type1,
-                      const RefRttType *ref_rtt_type2)
+wasm_refrttntype_equal(const RefRttNType *ref_rttn_type1,
+                       const RefRttNType *ref_rttn_type2,
+                       const WASMTypePtr *types, uint32 type_count)
 {
-    return (ref_rtt_type1->type_idx == ref_rtt_type2->type_idx) ? true : false;
+    return wasm_refrttntype_equal_recursive(ref_rttn_type1, ref_rttn_type2,
+                                            types, type_count, NULL);
+}
+
+static bool
+wasm_refrtttype_equal_recursive(const RefRttType *ref_rtt_type1,
+                                const RefRttType *ref_rtt_type2,
+                                const WASMTypePtr *types, uint32 type_count,
+                                TypeIdxList type_idx_list)
+{
+    return type_idx_equal_recursive(ref_rtt_type1->type_idx,
+                                    ref_rtt_type2->type_idx, types, type_count,
+                                    type_idx_list);
 }
 
 bool
-wasm_reftype_equal(uint8 type1, const WASMRefType *reftype1, uint8 type2,
-                   const WASMRefType *reftype2)
+wasm_refrtttype_equal(const RefRttType *ref_rtt_type1,
+                      const RefRttType *ref_rtt_type2, const WASMTypePtr *types,
+                      uint32 type_count)
 {
-    /* For (ref null func/extern/any/eq/i31/data), they are same as
-       funcref/externref/anyref/eqref/i31ref/dataref and have been
+    return wasm_refrtttype_equal_recursive(ref_rtt_type1, ref_rtt_type2, types,
+                                           type_count, NULL);
+}
+
+static bool
+wasm_reftype_equal_recursive(uint8 type1, const WASMRefType *reftype1,
+                             uint8 type2, const WASMRefType *reftype2,
+                             const WASMTypePtr *types, uint32 type_count,
+                             TypeIdxList type_idx_list)
+{
+    /* For (ref null func/any/eq/i31/data), they are same as
+       funcref/anyref/eqref/i31ref/dataref and have been
        converted into to the related one-byte type when loading, so here
        we don't consider the situations again:
-         one is (ref null func/extern/any/eq/i31/data),
-         the other is funcref/externref/anyref/eqref/i31ref/dataref. */
+         one is (ref null func/any/eq/i31/data),
+         the other is funcref/anyref/eqref/i31ref/dataref. */
     if (type1 != type2)
         return false;
 
@@ -590,8 +784,9 @@ wasm_reftype_equal(uint8 type1, const WASMRefType *reftype1, uint8 type2,
     if (type1 == (uint8)REF_TYPE_HT_NULLABLE
         || type1 == (uint8)REF_TYPE_HT_NON_NULLABLE) {
         /* (ref null ht) or (ref ht) */
-        return wasm_refheaptype_equal((RefHeapType_Common *)reftype1,
-                                      (RefHeapType_Common *)reftype2);
+        return wasm_refheaptype_equal_recursive(
+            (RefHeapType_Common *)reftype1, (RefHeapType_Common *)reftype2,
+            types, type_count, type_idx_list);
     }
     /* (rtt n i) and (rtt i) have been converted into
        (ref (rtt n i)) and (ref (rtt i)) in wasm/aot loader,
@@ -599,18 +794,29 @@ wasm_reftype_equal(uint8 type1, const WASMRefType *reftype1, uint8 type2,
 #if 0
     else if (type1 == (uint8)REF_TYPE_RTTN) {
         /* (rtt n i) */
-        return wasm_refrttntype_equal((RefRttNType *)reftype1,
-                                      (RefRttNType *)reftype2);
+        return wasm_refrttntype_equal_recursive((RefRttNType *)reftype1,
+                                                (RefRttNType *)reftype2, types,
+                                                type_count, type_idx_list);
     }
     else if (type1 == (uint8)REF_TYPE_RTT) {
         /* (rtt i) */
-        return wasm_refrtttype_equal((RefRttType *)reftype1,
-                                     (RefRttType *)reftype2);
+        return wasm_refrtttype_equal_recursive((RefRttType *)reftype1,
+                                               (RefRttType *)reftype2, types,
+                                               type_count, type_idx_list);
     }
 #endif
 
     bh_assert(0);
     return false;
+}
+
+bool
+wasm_reftype_equal(uint8 type1, const WASMRefType *reftype1, uint8 type2,
+                   const WASMRefType *reftype2, const WASMTypePtr *types,
+                   uint32 type_count)
+{
+    return wasm_reftype_equal_recursive(type1, reftype1, type2, reftype2, types,
+                                        type_count, NULL);
 }
 
 inline static bool
@@ -623,13 +829,6 @@ inline static bool
 wasm_is_reftype_supers_of_func(uint8 type)
 {
     return (type == REF_TYPE_FUNCREF || type == REF_TYPE_ANYREF) ? true : false;
-}
-
-inline static bool
-wasm_is_reftype_supers_of_extern(uint8 type)
-{
-    return (type == REF_TYPE_EXTERNREF || type == REF_TYPE_ANYREF) ? true
-                                                                   : false;
 }
 
 inline static bool
@@ -649,26 +848,39 @@ wasm_is_reftype_supers_of_data(uint8 type)
 }
 
 inline static bool
-wasm_is_reftype_supers_of_rtt_nullable(uint8 type_super,
-                                       const WASMRefType *ref_type_super,
-                                       uint32 type_idx_of_sub)
+wasm_is_reftype_supers_of_array(uint8 type)
+{
+    return (type == REF_TYPE_ARRAYREF || wasm_is_reftype_supers_of_data(type))
+               ? true
+               : false;
+}
+
+static bool
+wasm_is_reftype_supers_of_rtt_nullable(
+    uint8 type_super, const WASMRefType *ref_type_super, uint32 type_idx_of_sub,
+    const WASMTypePtr *types, uint32 type_count, TypeIdxList type_idx_list)
 {
     /* (ref null (rtt i)) <: [ (ref null (rtt i), eqref, anyref ] */
 
     /* super type is (ref null (rtt i)) */
     if (type_super == REF_TYPE_HT_NULLABLE
         && wasm_is_refheaptype_rtt(&ref_type_super->ref_ht_common)
-        && ref_type_super->ref_ht_rtt.type_idx == type_idx_of_sub)
+        && type_idx_equal_recursive(ref_type_super->ref_ht_rtt.type_idx,
+                                    type_idx_of_sub, types, type_count,
+                                    type_idx_list))
         return true;
 
     /* super type is eqref or anyref */
     return wasm_is_reftype_supers_of_eq(type_super);
 }
 
-inline static bool
+static bool
 wasm_is_reftype_supers_of_rttn_nullable(uint8 type_super,
                                         const WASMRefType *ref_type_super,
-                                        uint32 n_of_sub, uint32 type_idx_of_sub)
+                                        uint32 n_of_sub, uint32 type_idx_of_sub,
+                                        const WASMTypePtr *types,
+                                        uint32 type_count,
+                                        TypeIdxList type_idx_list)
 {
     /* (ref null (rtt n i)) <: [ (ref null (rtt n i), (ref null (rtt i),
                                  eqref, anyref ] */
@@ -676,38 +888,44 @@ wasm_is_reftype_supers_of_rttn_nullable(uint8 type_super,
     /* super type is (ref null (rtt n i) */
     if (type_super == REF_TYPE_HT_NULLABLE
         && wasm_is_refheaptype_rttn(&ref_type_super->ref_ht_common)
-        && ref_type_super->ref_ht_rttn.n == n_of_sub
-        && ref_type_super->ref_ht_rttn.type_idx == type_idx_of_sub)
+        && ref_type_super->ref_ht_rttn.n <= n_of_sub
+        && type_idx_equal_recursive(ref_type_super->ref_ht_rttn.type_idx,
+                                    type_idx_of_sub, types, type_count,
+                                    type_idx_list))
         return true;
 
     /* super type is (ref null (rtt i), eqref or anyref */
     return wasm_is_reftype_supers_of_rtt_nullable(type_super, ref_type_super,
-                                                  type_idx_of_sub);
+                                                  type_idx_of_sub, types,
+                                                  type_count, type_idx_list);
 }
 
-inline static bool
-wasm_is_reftype_supers_of_rtt_non_nullable(uint8 type_super,
-                                           const WASMRefType *ref_type_super,
-                                           uint32 type_idx_of_sub)
+static bool
+wasm_is_reftype_supers_of_rtt_non_nullable(
+    uint8 type_super, const WASMRefType *ref_type_super, uint32 type_idx_of_sub,
+    const WASMTypePtr *types, uint32 type_count, TypeIdxList type_idx_list)
 {
     /* (ref (rtt i)) <: [ (ref (rtt i), (ref null (rtt i), eqref, anyref ] */
 
     /* super type is (ref (rtt i) */
     if (type_super == REF_TYPE_HT_NON_NULLABLE
         && wasm_is_refheaptype_rtt(&ref_type_super->ref_ht_common)
-        && ref_type_super->ref_ht_rtt.type_idx == type_idx_of_sub)
+        && type_idx_equal_recursive(ref_type_super->ref_ht_rtt.type_idx,
+                                    type_idx_of_sub, types, type_count,
+                                    type_idx_list))
         return true;
 
     /* super type is (ref null (rtt i)), eqref or anyref */
     return wasm_is_reftype_supers_of_rtt_nullable(type_super, ref_type_super,
-                                                  type_idx_of_sub);
+                                                  type_idx_of_sub, types,
+                                                  type_count, type_idx_list);
 }
 
-inline static bool
-wasm_is_reftype_supers_of_rttn_non_nullable(uint8 type_super,
-                                            const WASMRefType *ref_type_super,
-                                            uint32 n_of_sub,
-                                            uint32 type_idx_of_sub)
+static bool
+wasm_is_reftype_supers_of_rttn_non_nullable(
+    uint8 type_super, const WASMRefType *ref_type_super, uint32 n_of_sub,
+    uint32 type_idx_of_sub, const WASMTypePtr *types, uint32 type_count,
+    TypeIdxList type_idx_list)
 {
     /* (ref (rtt n i)) <: [ (ref (rtt n i), (ref (rtt i)),
      *                      (ref null (rtt n i)), (ref null (rtt i),
@@ -716,24 +934,29 @@ wasm_is_reftype_supers_of_rttn_non_nullable(uint8 type_super,
     if (type_super == REF_TYPE_HT_NON_NULLABLE) {
         /* super type is (ref (rtt n i)) */
         if (wasm_is_refheaptype_rttn(&ref_type_super->ref_ht_common)
-            && ref_type_super->ref_ht_rttn.n == n_of_sub
-            && ref_type_super->ref_ht_rttn.type_idx == type_idx_of_sub)
+            && ref_type_super->ref_ht_rttn.n <= n_of_sub
+            && type_idx_equal_recursive(ref_type_super->ref_ht_rttn.type_idx,
+                                        type_idx_of_sub, types, type_count,
+                                        type_idx_list))
             return true;
         /* super type is (ref (rtt i)) */
         else if (wasm_is_refheaptype_rtt(&ref_type_super->ref_ht_common)
-                 && ref_type_super->ref_ht_rtt.type_idx == type_idx_of_sub)
+                 && type_idx_equal_recursive(
+                     ref_type_super->ref_ht_rtt.type_idx, type_idx_of_sub,
+                     types, type_count, type_idx_list))
             return true;
     }
 
     /* super type is (ref null (rtt n i), eqref or anyref */
-    return wasm_is_reftype_supers_of_rttn_nullable(type_super, ref_type_super,
-                                                   n_of_sub, type_idx_of_sub);
+    return wasm_is_reftype_supers_of_rttn_nullable(
+        type_super, ref_type_super, n_of_sub, type_idx_of_sub, types,
+        type_count, type_idx_list);
 }
 
 bool
 wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
                            uint8 type2, const WASMRefType *ref_type2,
-                           const WASMType **types, uint32 type_count)
+                           const WASMTypePtr *types, uint32 type_count)
 {
     /* (rtt n i) and (rtt i) have been converted into
        (ref (rtt n i)) and (ref (rtt i)) in wasm/aot loader,
@@ -758,8 +981,6 @@ wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
      *   |        |-> dataref -> (ref null $t) -> (ref $t), $t is struct/array
      *   |
      *   |-> funcref -> (ref null $t) -> (ref $t), $t is func
-     *   |
-     *   |-> externref
      */
 
     if (type1 == REF_TYPE_ANYREF) {
@@ -774,10 +995,6 @@ wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
         /* func <: [func, any] */
         return wasm_is_reftype_supers_of_func(type2);
     }
-    else if (type1 == REF_TYPE_EXTERNREF) {
-        /* extern <: [extern, any] */
-        return wasm_is_reftype_supers_of_extern(type2);
-    }
     else if (type1 == REF_TYPE_I31REF) {
         /* i31 <: [i31, eq, any] */
         return wasm_is_reftype_supers_of_i31(type2);
@@ -786,37 +1003,47 @@ wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
         /* data <: [data, eq, any] */
         return wasm_is_reftype_supers_of_data(type2);
     }
+    else if (type1 == REF_TYPE_ARRAYREF) {
+        /* array <: [array, data, eq, any] */
+        return wasm_is_reftype_supers_of_array(type2);
+    }
     else if (type1 == REF_TYPE_HT_NULLABLE) {
         if (wasm_is_refheaptype_rtt(&ref_type1->ref_ht_common)) {
             /* reftype1 is (ref null (rtt i)), the super type can be:
                  (ref null (rtt i), eqref and anyref */
             return wasm_is_reftype_supers_of_rtt_nullable(
-                type2, ref_type2, ref_type1->ref_ht_rtt.type_idx);
+                type2, ref_type2, ref_type1->ref_ht_rtt.type_idx, types,
+                type_count, NULL);
         }
         else if (wasm_is_refheaptype_rttn(&ref_type1->ref_ht_common)) {
             /* reftype1 is (ref null (rtt n i)), the super type can be:
                  (ref null (rtt n i), (ref null (rtt i)), eqref and anyref */
             return wasm_is_reftype_supers_of_rttn_nullable(
                 type2, ref_type2, ref_type1->ref_ht_rttn.n,
-                ref_type1->ref_ht_rttn.type_idx);
+                ref_type1->ref_ht_rttn.type_idx, types, type_count, NULL);
         }
         else if (wasm_is_refheaptype_typeidx(&ref_type1->ref_ht_common)) {
             /* reftype1 is (ref null $t), the super type can be:
                  (ref null $t), dataref, eqref, funcref and anyref */
             if (type2 == REF_TYPE_HT_NULLABLE
-                && wasm_is_refheaptype_typeidx(&ref_type2->ref_ht_common)
-                && ref_type1->ref_ht_typeidx.type_idx
-                       == ref_type2->ref_ht_typeidx.type_idx)
-                return true;
+                && wasm_is_refheaptype_typeidx(&ref_type2->ref_ht_common)) {
+                return type_idx_equal_recursive(
+                    ref_type1->ref_ht_typeidx.type_idx,
+                    ref_type2->ref_ht_typeidx.type_idx, types, type_count,
+                    NULL);
+            }
             else if (types[ref_type1->ref_ht_typeidx.type_idx]->type_flag
                      == WASM_TYPE_FUNC)
                 return wasm_is_reftype_supers_of_func(type2);
+            else if (types[ref_type1->ref_ht_typeidx.type_idx]->type_flag
+                     == WASM_TYPE_ARRAY)
+                return wasm_is_reftype_supers_of_array(type2);
             else
                 return wasm_is_reftype_supers_of_data(type2);
         }
         else {
-            /* (ref null (func/extern/any/eq/i31/data)) have been converted into
-               funcref/externref/anyref/eqref/i31ref/dataref when loading */
+            /* (ref null (func/any/eq/i31/data)) have been converted into
+               funcref/anyref/eqref/i31ref/dataref when loading */
             bh_assert(0);
         }
     }
@@ -825,7 +1052,8 @@ wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
             /* reftype1 is (ref (rtt i)), the super type can be:
                  (ref (rtt i), (ref null (rtt i)), eqref and anyref */
             return wasm_is_reftype_supers_of_rtt_non_nullable(
-                type2, ref_type2, ref_type1->ref_ht_rtt.type_idx);
+                type2, ref_type2, ref_type1->ref_ht_rtt.type_idx, types,
+                type_count, NULL);
         }
         else if (wasm_is_refheaptype_rttn(&ref_type1->ref_ht_common)) {
             /* reftype1 is (ref (rtt n i)), the super type can be:
@@ -833,26 +1061,91 @@ wasm_reftype_is_subtype_of(uint8 type1, const WASMRefType *ref_type1,
                  (ref null (rtt i)), eqref and data ref */
             return wasm_is_reftype_supers_of_rttn_non_nullable(
                 type2, ref_type2, ref_type1->ref_ht_rttn.n,
-                ref_type1->ref_ht_rttn.type_idx);
+                ref_type1->ref_ht_rttn.type_idx, types, type_count, NULL);
         }
         else if (wasm_is_refheaptype_typeidx(&ref_type1->ref_ht_common)) {
-            /* reftype1 is (ref $t), the super type can be:
-                 (ref $t), (ref null $t), dataref, eqref, funcref and anyref */
+            /* reftype1 is (ref $t), the super type might be:
+                 (ref $t), (ref null $t), arrayref, dataref, eqref,
+                 funcref and anyref */
             if ((type2 == REF_TYPE_HT_NULLABLE
                  || type2 == REF_TYPE_HT_NON_NULLABLE)
-                && wasm_is_refheaptype_typeidx(&ref_type2->ref_ht_common)
-                && ref_type1->ref_ht_typeidx.type_idx
-                       == ref_type2->ref_ht_typeidx.type_idx)
-                return true;
+                && wasm_is_refheaptype_typeidx(&ref_type2->ref_ht_common)) {
+                return type_idx_equal_recursive(
+                    ref_type1->ref_ht_typeidx.type_idx,
+                    ref_type2->ref_ht_typeidx.type_idx, types, type_count,
+                    NULL);
+            }
             else if (types[ref_type1->ref_ht_typeidx.type_idx]->type_flag
-                     == WASM_TYPE_FUNC)
+                     == WASM_TYPE_FUNC) {
+                /* the super type is (ref null func) or (ref func) */
+                if ((type2 == REF_TYPE_HT_NULLABLE
+                     || type2 == REF_TYPE_HT_NON_NULLABLE)
+                    && ref_type2->ref_ht_common.heap_type == HEAP_TYPE_FUNC)
+                    return true;
+                /* the super type is funcref or anyref */
                 return wasm_is_reftype_supers_of_func(type2);
-            else
+            }
+            else if (types[ref_type1->ref_ht_typeidx.type_idx]->type_flag
+                     == WASM_TYPE_ARRAY) {
+                /* the super type is (ref null array) or (ref array) */
+                if ((type2 == REF_TYPE_HT_NULLABLE
+                     || type2 == REF_TYPE_HT_NON_NULLABLE)
+                    && ref_type2->ref_ht_common.heap_type == HEAP_TYPE_ARRAY)
+                    return true;
+                /* the super type is arrayref, dataref, eqref or anyref */
+                return wasm_is_reftype_supers_of_array(type2);
+            }
+            else {
+                /* the super type is (ref null data) or (ref data) */
+                if ((type2 == REF_TYPE_HT_NULLABLE
+                     || type2 == REF_TYPE_HT_NON_NULLABLE)
+                    && ref_type2->ref_ht_common.heap_type == HEAP_TYPE_DATA)
+                    return true;
+                /* the super type is dataref, eqref or anyref */
                 return wasm_is_reftype_supers_of_data(type2);
+            }
+        }
+        else if (wasm_is_refheaptype_common(&ref_type1->ref_ht_common)) {
+            /* reftype1 is (ref func/any/eq/i31/data), the super type
+               can be itself, or supers of
+               funcref/anyref/eqref/i31ref/dataref */
+            if (wasm_reftype_equal(type1, ref_type1, type2, ref_type2, types,
+                                   type_count))
+                return true;
+            else {
+                int32 heap_type = ref_type1->ref_ht_common.heap_type;
+                if (heap_type == HEAP_TYPE_ANY) {
+                    /* (ref any) <: anyref */
+                    return type2 == REF_TYPE_ANYREF ? true : false;
+                }
+                else if (heap_type == HEAP_TYPE_EQ) {
+                    /* (ref eq) <: [eqref, anyref] */
+                    return wasm_is_reftype_supers_of_eq(type2);
+                }
+                else if (heap_type == HEAP_TYPE_FUNC) {
+                    /* (ref func) <: [funcref, anyref] */
+                    return wasm_is_reftype_supers_of_func(type2);
+                }
+                else if (heap_type == HEAP_TYPE_I31) {
+                    /* (ref i31) <: [i31ref, eqref, anyref] */
+                    return wasm_is_reftype_supers_of_i31(type2);
+                }
+                else if (heap_type == HEAP_TYPE_DATA) {
+                    /* (ref data) <: [dataref, eqref, anyref] */
+                    return wasm_is_reftype_supers_of_data(type2);
+                }
+                else if (heap_type == HEAP_TYPE_ARRAY) {
+                    /* (ref array) <: [arrayref, dataref, eqref, anyref] */
+                    return wasm_is_reftype_supers_of_array(type2);
+                }
+                else {
+                    bh_assert(0);
+                }
+            }
         }
         else {
-            /* (ref null (func/extern/any/eq/i31/data)) have been converted into
-               funcref/externref/anyref/eqref/i31ref/dataref when loading */
+            /* unknown type detected */
+            LOG_ERROR("unknown sub type 0x%02x", type1);
             bh_assert(0);
         }
     }
@@ -932,7 +1225,7 @@ reftype_equal(void *type1, void *type2)
     WASMRefType *reftype2 = (WASMRefType *)type2;
 
     return wasm_reftype_equal(reftype1->ref_type, reftype1, reftype2->ref_type,
-                              reftype2);
+                              reftype2, NULL, 0);
 }
 
 WASMRefType *
@@ -1047,11 +1340,34 @@ wasm_set_refheaptype_common(RefHeapType_Common *ref_ht_common, bool nullable,
     ref_ht_common->heap_type = heap_type;
 }
 
+WASMRefType *
+wasm_reftype_map_find(WASMRefTypeMap *ref_type_maps, uint32 ref_type_map_count,
+                      uint32 index_to_find)
+{
+    int low = 0, mid;
+    int high = (int32)ref_type_map_count - 1;
+    uint32 index;
+
+    while (low <= high) {
+        mid = (low + high) / 2;
+        index = ref_type_maps[mid].index;
+        if (index_to_find == index) {
+            return ref_type_maps[mid].ref_type;
+        }
+        else if (index_to_find < index)
+            high = mid - 1;
+        else
+            low = mid + 1;
+    }
+
+    return NULL;
+}
+
 HashMap *
 wasm_reftype_set_create(uint32 size)
 {
     HashMap *ref_type_set = bh_hash_map_create(
-        32, false, reftype_hash, reftype_equal, NULL, wasm_runtime_free);
+        size, false, reftype_hash, reftype_equal, NULL, wasm_runtime_free);
 
     return ref_type_set;
 }

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1296,8 +1296,9 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     cur_func_type = cur_func->u.func_import->func_type;
                 else
                     cur_func_type = cur_func->u.func->func_type;
-                if (!wasm_type_equal((WASMType *)cur_type,
-                                     (WASMType *)cur_func_type)) {
+                if (!wasm_type_equal(
+                        (WASMType *)cur_type, (WASMType *)cur_func_type,
+                        module->module->types, module->module->type_count)) {
                     wasm_set_exception(module, "indirect call type mismatch");
                     goto got_exception;
                 }

--- a/core/iwasm/interpreter/wasm_interp_fast.c
+++ b/core/iwasm/interpreter/wasm_interp_fast.c
@@ -1273,8 +1273,9 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     cur_func_type = cur_func->u.func_import->func_type;
                 else
                     cur_func_type = cur_func->u.func->func_type;
-                if (!wasm_type_equal((WASMType *)cur_type,
-                                     (WASMType *)cur_func_type)) {
+                if (!wasm_type_equal(
+                        (WASMType *)cur_type, (WASMType *)cur_func_type,
+                        module->module->types, module->module->type_count)) {
                     wasm_set_exception(module, "indirect call type mismatch");
                     goto got_exception;
                 }

--- a/core/iwasm/interpreter/wasm_opcode.h
+++ b/core/iwasm/interpreter/wasm_opcode.h
@@ -308,19 +308,23 @@ typedef enum WASMGCEXTOpcode {
     WASM_OP_BR_ON_CAST = 0x42,      /* br_on_cast */
     WASM_OP_BR_ON_CAST_FAIL = 0x43, /* br_on_cast_fail */
 
-    WASM_OP_REF_IS_FUNC = 0x50, /* ref.is_func */
-    WASM_OP_REF_IS_DATA = 0x51, /* ref.is_data */
-    WASM_OP_REF_IS_I31 = 0x52,  /* ref.is_i31 */
-    WASM_OP_REF_AS_FUNC = 0x58, /* ref.as_func */
-    WASM_OP_REF_AS_DATA = 0x59, /* ref.as_data */
-    WASM_OP_REF_AS_I31 = 0x5a,  /* ref.as_i31 */
+    WASM_OP_REF_IS_FUNC = 0x50,  /* ref.is_func */
+    WASM_OP_REF_IS_DATA = 0x51,  /* ref.is_data */
+    WASM_OP_REF_IS_I31 = 0x52,   /* ref.is_i31 */
+    WASM_OP_REF_IS_ARRAY = 0x53, /* ref.is_array */
+    WASM_OP_REF_AS_FUNC = 0x58,  /* ref.as_func */
+    WASM_OP_REF_AS_DATA = 0x59,  /* ref.as_data */
+    WASM_OP_REF_AS_I31 = 0x5a,   /* ref.as_i31 */
+    WASM_OP_REF_AS_ARRAY = 0x5b, /* ref.as_array */
 
-    WASM_OP_BR_ON_FUNC = 0x60,     /* br_on_func */
-    WASM_OP_BR_ON_DATA = 0x61,     /* br_on_data */
-    WASM_OP_BR_ON_I31 = 0x62,      /* br_on_i31 */
-    WASM_OP_BR_ON_NON_FUNC = 0x63, /* br_on_non_func */
-    WASM_OP_BR_ON_NON_DATA = 0x64, /* br_on_non_data */
-    WASM_OP_BR_ON_NON_I31 = 0x65,  /* br_on_non_i31 */
+    WASM_OP_BR_ON_FUNC = 0x60,      /* br_on_func */
+    WASM_OP_BR_ON_DATA = 0x61,      /* br_on_data */
+    WASM_OP_BR_ON_I31 = 0x62,       /* br_on_i31 */
+    WASM_OP_BR_ON_NON_FUNC = 0x63,  /* br_on_non_func */
+    WASM_OP_BR_ON_NON_DATA = 0x64,  /* br_on_non_data */
+    WASM_OP_BR_ON_NON_I31 = 0x65,   /* br_on_non_i31 */
+    WASM_OP_BR_ON_ARRAY = 0x66,     /* br_on_array */
+    WASM_OP_BR_ON_NON_ARRAY = 0x67, /* br_on_non_array */
 } WASMGCEXTOpcode;
 
 typedef enum WASMMiscEXTOpcode {

--- a/tests/wamr-test-suites/spec-test-script/all.py
+++ b/tests/wamr-test-suites/spec-test-script/all.py
@@ -19,6 +19,10 @@ import time
 
 """
 The script itself has to be put under the same directory with the "spec".
+To run single spec case:
+  cd workspace
+  python2.7 runtest.py --wast2wasm spec/interpreter/wasm --interpreter iwasm
+            --aot-compiler wamrc --gc --loader-only spec/test/core/xxx.wast
 """
 
 PLATFORM_NAME = os.uname().sysname.lower()
@@ -28,7 +32,6 @@ SPEC_TEST_DIR = "spec/test/core"
 WAST2WASM_CMD = "./wabt/out/gcc/Release/wat2wasm"
 SPEC_INTERPRETER_CMD = "spec/interpreter/wasm"
 WAMRC_CMD = "../../../wamr-compiler/build/wamrc"
-
 
 class TargetAction(argparse.Action):
     TARGET_MAP = {
@@ -53,12 +56,16 @@ def ignore_the_case(
     multi_module_flag=False,
     multi_thread_flag=False,
     simd_flag=False,
+    gc_flag=False,
     xip_flag=False,
 ):
     if case_name in ["comments", "inline-module", "names"]:
         return True
 
     if not multi_module_flag and case_name in ["imports", "linking"]:
+        return True
+
+    if gc_flag and case_name in ["func_bind", "let"]:
         return True
 
     if "i386" == target and case_name in ["float_exprs"]:
@@ -119,6 +126,7 @@ def test_case(
         multi_module_flag,
         multi_thread_flag,
         simd_flag,
+        gc_flag,
         xip_flag,
     ):
         return True

--- a/tests/wamr-test-suites/spec-test-script/gc_ignore_cases.patch
+++ b/tests/wamr-test-suites/spec-test-script/gc_ignore_cases.patch
@@ -1,5 +1,5 @@
 diff --git a/test/core/binary.wast b/test/core/binary.wast
-index ebebd2ea..94873528 100644
+index 1f76dc13..f4512ade 100644
 --- a/test/core/binary.wast
 +++ b/test/core/binary.wast
 @@ -161,7 +161,7 @@
@@ -171,7 +171,7 @@ index 35e8c917..a7a459df 100644
  
  ;; Syntax errors
 diff --git a/test/core/linking.wast b/test/core/linking.wast
-index 994e0f49..d0bfb5f6 100644
+index 85de43d8..6b218e3b 100644
 --- a/test/core/linking.wast
 +++ b/test/core/linking.wast
 @@ -64,6 +64,7 @@
@@ -190,7 +190,7 @@ index 994e0f49..d0bfb5f6 100644
  
  
  (assert_unlinkable
-@@ -165,6 +167,7 @@
+@@ -317,6 +319,7 @@
    )
  )
  
@@ -198,7 +198,7 @@ index 994e0f49..d0bfb5f6 100644
  (assert_return (invoke $Mt "call" (i32.const 2)) (i32.const 4))
  (assert_return (invoke $Nt "Mt.call" (i32.const 2)) (i32.const 4))
  (assert_return (invoke $Nt "call" (i32.const 2)) (i32.const 5))
-@@ -187,6 +190,7 @@
+@@ -339,6 +342,7 @@
  
  (assert_return (invoke $Nt "call" (i32.const 3)) (i32.const -4))
  (assert_trap (invoke $Nt "call" (i32.const 4)) "indirect call type mismatch")
@@ -206,7 +206,7 @@ index 994e0f49..d0bfb5f6 100644
  
  (module $Ot
    (type (func (result i32)))
-@@ -201,6 +205,7 @@
+@@ -353,6 +357,7 @@
    )
  )
  
@@ -214,7 +214,7 @@ index 994e0f49..d0bfb5f6 100644
  (assert_return (invoke $Mt "call" (i32.const 3)) (i32.const 4))
  (assert_return (invoke $Nt "Mt.call" (i32.const 3)) (i32.const 4))
  (assert_return (invoke $Nt "call Mt.call" (i32.const 3)) (i32.const 4))
-@@ -225,6 +230,7 @@
+@@ -377,6 +382,7 @@
  (assert_trap (invoke $Ot "call" (i32.const 0)) "uninitialized element")
  
  (assert_trap (invoke $Ot "call" (i32.const 20)) "undefined element")
@@ -222,7 +222,7 @@ index 994e0f49..d0bfb5f6 100644
  
  (module
    (table (import "Mt" "tab") 0 funcref)
-@@ -263,6 +269,7 @@
+@@ -415,6 +421,7 @@
  
  ;; Unlike in the v1 spec, active element segments stored before an
  ;; out-of-bounds access persist after the instantiation failure.
@@ -230,7 +230,7 @@ index 994e0f49..d0bfb5f6 100644
  (assert_trap
    (module
      (table (import "Mt" "tab") 10 funcref)
-@@ -274,7 +281,9 @@
+@@ -426,7 +433,9 @@
  )
  (assert_return (invoke $Mt "call" (i32.const 7)) (i32.const 0))
  (assert_trap (invoke $Mt "call" (i32.const 8)) "uninitialized element")
@@ -240,7 +240,7 @@ index 994e0f49..d0bfb5f6 100644
  (assert_trap
    (module
      (table (import "Mt" "tab") 10 funcref)
-@@ -286,6 +295,7 @@
+@@ -438,6 +447,7 @@
    "out of bounds memory access"
  )
  (assert_return (invoke $Mt "call" (i32.const 7)) (i32.const 0))
@@ -248,23 +248,23 @@ index 994e0f49..d0bfb5f6 100644
  
  
  (module $Mtable_ex
-@@ -299,6 +309,7 @@
+@@ -455,6 +465,7 @@
    (table (import "Mtable_ex" "t-extern") 1 externref)
  )
  
 +(;
  (assert_unlinkable
-   (module (table (import "Mtable_ex" "t-func") 1 externref))
+   (module (table (import "Mtable_ex" "t-refnull") 1 (ref null func)))
    "incompatible import type"
-@@ -307,6 +318,7 @@
-   (module (table (import "Mtable_ex" "t-extern") 1 funcref))
+@@ -481,6 +492,7 @@
+   (module (table (import "Mtable_ex" "t-refnull") 1 externref))
    "incompatible import type"
  )
 +;)
  
  
  ;; Memories
-@@ -346,10 +358,12 @@
+@@ -520,10 +532,12 @@
    )
  )
  
@@ -277,7 +277,7 @@ index 994e0f49..d0bfb5f6 100644
  
  (module
    (memory (import "Mm" "mem") 0)
-@@ -372,6 +386,7 @@
+@@ -546,6 +560,7 @@
    )
  )
  
@@ -285,7 +285,7 @@ index 994e0f49..d0bfb5f6 100644
  (assert_return (invoke $Pm "grow" (i32.const 0)) (i32.const 1))
  (assert_return (invoke $Pm "grow" (i32.const 2)) (i32.const 1))
  (assert_return (invoke $Pm "grow" (i32.const 0)) (i32.const 3))
-@@ -380,6 +395,7 @@
+@@ -554,6 +569,7 @@
  (assert_return (invoke $Pm "grow" (i32.const 0)) (i32.const 5))
  (assert_return (invoke $Pm "grow" (i32.const 1)) (i32.const -1))
  (assert_return (invoke $Pm "grow" (i32.const 0)) (i32.const 5))
@@ -293,7 +293,7 @@ index 994e0f49..d0bfb5f6 100644
  
  (assert_unlinkable
    (module
-@@ -403,8 +419,10 @@
+@@ -577,8 +593,10 @@
    )
    "out of bounds memory access"
  )
@@ -304,7 +304,7 @@ index 994e0f49..d0bfb5f6 100644
  
  (assert_trap
    (module
-@@ -416,7 +434,9 @@
+@@ -590,7 +608,9 @@
    )
    "out of bounds table access"
  )
@@ -314,7 +314,7 @@ index 994e0f49..d0bfb5f6 100644
  
  ;; Store is modified if the start function traps.
  (module $Ms
-@@ -432,6 +452,7 @@
+@@ -606,6 +626,7 @@
  )
  (register "Ms" $Ms)
  
@@ -322,7 +322,7 @@ index 994e0f49..d0bfb5f6 100644
  (assert_trap
    (module
      (import "Ms" "memory" (memory 1))
-@@ -451,3 +472,4 @@
+@@ -625,3 +646,4 @@
  
  (assert_return (invoke $Ms "get memory[0]") (i32.const 104))  ;; 'h'
  (assert_return (invoke $Ms "get table[0]") (i32.const 0xdead))
@@ -342,10 +342,10 @@ index adb5cb78..590f6262 100644
      (i32.add (local.get $x) (i32.const 1))
    )
 diff --git a/test/core/select.wast b/test/core/select.wast
-index 046e6fe2..b6770238 100644
+index fbe51be1..bb209d9b 100644
 --- a/test/core/select.wast
 +++ b/test/core/select.wast
-@@ -324,6 +324,7 @@
+@@ -368,6 +368,7 @@
    (module (func $arity-0 (select (result) (nop) (nop) (i32.const 1))))
    "invalid result arity"
  )
@@ -353,7 +353,7 @@ index 046e6fe2..b6770238 100644
  (assert_invalid
    (module (func $arity-2 (result i32 i32)
      (select (result i32 i32)
-@@ -334,6 +335,7 @@
+@@ -378,6 +379,7 @@
    ))
    "invalid result arity"
  )

--- a/tests/wamr-test-suites/spec-test-script/runtest.py
+++ b/tests/wamr-test-suites/spec-test-script/runtest.py
@@ -1212,9 +1212,6 @@ if __name__ == "__main__":
                         if not compile_wast_to_wasm(form, temp_files[0], temp_files[1], opts):
                             raise Exception("compile wast to wasm failed")
 
-                        if opts.loader_only:
-                            continue
-
                         if test_aot:
                             r = compile_wasm_to_aot(temp_files[1], temp_files[2], True, opts, r)
                             try:
@@ -1229,9 +1226,6 @@ if __name__ == "__main__":
                 else:
                     if not compile_wast_to_wasm(form, wast_tempfile, wasm_tempfile, opts):
                         raise Exception("compile wast to wasm failed")
-
-                    if opts.loader_only:
-                        continue
 
                     if test_aot:
                         r = compile_wasm_to_aot(wasm_tempfile, aot_tempfile, True, opts, r)

--- a/tests/wamr-test-suites/spec-test-script/thread_proposal_ignore_cases.patch
+++ b/tests/wamr-test-suites/spec-test-script/thread_proposal_ignore_cases.patch
@@ -211,3 +211,23 @@ index c3456a61..83fc2815 100644
  (wait $T1)
  (wait $T2)
 +;)
+diff --git a/test/core/unreached-invalid.wast b/test/core/unreached-invalid.wast
+index 6ef4ac55..9a2387a3 100644
+--- a/test/core/unreached-invalid.wast
++++ b/test/core/unreached-invalid.wast
+@@ -535,6 +535,7 @@
+   ))
+   "type mismatch"
+ )
++(; invalid case, the module is fine for the latest spec interpreter
+ (assert_invalid
+   (module (func $type-br_table-label-num-vs-label-num-after-unreachable
+     (block (result f64)
+@@ -549,6 +550,7 @@
+   ))
+   "type mismatch"
+ )
++;)
+ 
+ (assert_invalid
+   (module (func $type-block-value-nested-unreachable-num-vs-void

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -320,6 +320,7 @@ function spec_test()
         git restore . && git clean -ffd .
         git fetch gc
         git checkout -B gc_spec --track gc/master
+        git apply ../../spec-test-script/gc_ignore_cases.patch
 
         echo "compile the reference intepreter"
         pushd interpreter


### PR DESCRIPTION
Implement GC bytecode validation in loader stage, except for opcode
let and and func.bind. Pass the related spec cases.

And implement some GC object related APIs.

The source code may be not so elegant, we will optimize it in the future.