### PR TITLE
Fix execute_main not wait for other threads (#1137)

### DIFF
--- a/core/iwasm/common/wasm_application.c
+++ b/core/iwasm/common/wasm_application.c
@@ -10,6 +10,9 @@
 #if WASM_ENABLE_AOT != 0
 #include "../aot/aot_runtime.h"
 #endif
+#if WASM_ENABLE_THREAD_MGR != 0
+#include "../libraries/thread-mgr/thread_manager.h"
+#endif
 
 static void
 set_error_buf(char *error_buf, uint32 error_buf_size, const char *string)
@@ -76,9 +79,8 @@ check_main_func_type(const WASMType *type)
     return true;
 }
 
-bool
-wasm_application_execute_main(WASMModuleInstanceCommon *module_inst, int32 argc,
-                              char *argv[])
+static bool
+execute_main(WASMModuleInstanceCommon *module_inst, int32 argc, char *argv[])
 {
     WASMFunctionInstanceCommon *func;
     WASMType *func_type = NULL;
@@ -201,6 +203,28 @@ wasm_application_execute_main(WASMModuleInstanceCommon *module_inst, int32 argc,
     if (argv_buf_offset)
         wasm_runtime_module_free(module_inst, argv_buf_offset);
     return ret;
+}
+
+bool
+wasm_application_execute_main(WASMModuleInstanceCommon *module_inst, int32 argc,
+                              char *argv[])
+{
+    bool ret;
+#if WASM_ENABLE_THREAD_MGR != 0
+    WASMCluster *cluster;
+    WASMExecEnv *exec_env;
+#endif
+
+    ret = execute_main(module_inst, argc, argv);
+
+#if WASM_ENABLE_THREAD_MGR != 0
+    exec_env = wasm_runtime_get_exec_env_singleton(module_inst);
+    if (exec_env && (cluster = wasm_exec_env_get_cluster(exec_env))) {
+        wasm_cluster_wait_for_all_except_self(cluster, exec_env);
+    }
+#endif
+
+    return (ret && !wasm_runtime_get_exception(module_inst)) ? true : false;
 }
 
 #if WASM_ENABLE_MULTI_MODULE != 0
@@ -351,9 +375,9 @@ union ieee754_double {
     } ieee;
 };
 
-bool
-wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
-                              const char *name, int32 argc, char *argv[])
+static bool
+execute_func(WASMModuleInstanceCommon *module_inst, const char *name,
+             int32 argc, char *argv[])
 {
     WASMFunctionInstanceCommon *target_func;
     WASMModuleInstanceCommon *target_inst;
@@ -688,4 +712,26 @@ fail:
     bh_assert(exception);
     os_printf("%s\n", exception);
     return false;
+}
+
+bool
+wasm_application_execute_func(WASMModuleInstanceCommon *module_inst,
+                              const char *name, int32 argc, char *argv[])
+{
+    bool ret;
+#if WASM_ENABLE_THREAD_MGR != 0
+    WASMCluster *cluster;
+    WASMExecEnv *exec_env;
+#endif
+
+    ret = execute_func(module_inst, name, argc, argv);
+
+#if WASM_ENABLE_THREAD_MGR != 0
+    exec_env = wasm_runtime_get_exec_env_singleton(module_inst);
+    if (exec_env && (cluster = wasm_exec_env_get_cluster(exec_env))) {
+        wasm_cluster_wait_for_all_except_self(cluster, exec_env);
+    }
+#endif
+
+    return (ret && !wasm_runtime_get_exception(module_inst)) ? true : false;
 }

--- a/core/iwasm/common/wasm_exec_env.h
+++ b/core/iwasm/common/wasm_exec_env.h
@@ -100,6 +100,9 @@ typedef struct WASMExecEnv {
     korp_cond wait_cond;
     /* the count of threads which are joining current thread */
     uint32 wait_count;
+
+    /* whether current thread is detached */
+    bool thread_is_detached;
 #endif
 
 #if WASM_ENABLE_DEBUG_INTERP != 0

--- a/core/iwasm/libraries/thread-mgr/thread_manager.h
+++ b/core/iwasm/libraries/thread-mgr/thread_manager.h
@@ -106,6 +106,13 @@ void
 wasm_cluster_terminate_all_except_self(WASMCluster *cluster,
                                        WASMExecEnv *exec_env);
 
+void
+wams_cluster_wait_for_all(WASMCluster *cluster);
+
+void
+wasm_cluster_wait_for_all_except_self(WASMCluster *cluster,
+                                      WASMExecEnv *exec_env);
+
 bool
 wasm_cluster_add_exec_env(WASMCluster *cluster, WASMExecEnv *exec_env);
 
@@ -148,8 +155,6 @@ typedef struct WASMCurrentEnvStatus {
     uint64 signal_flag : 32;
     uint64 step_count : 16;
     uint64 running_status : 16;
-    korp_mutex wait_lock;
-    korp_cond wait_cond;
 } WASMCurrentEnvStatus;
 
 WASMCurrentEnvStatus *


### PR DESCRIPTION
Fix wasm_application_execute_main/wasm_application_execute_func not waiting for
other threads to terminate in multi-thread mode, which causes that the exception
thrown by other threads may haven't been spreaded to current main thread, and
cannot be detected by the caller, as reported in #1131.