### PR TITLE
Fix fast jit issues (#1208)

### DIFF
--- a/core/config.h
+++ b/core/config.h
@@ -102,12 +102,6 @@
 #define WASM_ENABLE_FAST_JIT_DUMP 0
 #endif
 
-#ifndef FAST_JIT_SPILL_CACHE_SIZE
-/* The size of fast jit spill cache in cell num, one cell num
-   occpuies 4 bytes */
-#define FAST_JIT_SPILL_CACHE_SIZE 32
-#endif
-
 #ifndef WASM_ENABLE_WAMR_COMPILER
 #define WASM_ENABLE_WAMR_COMPILER 0
 #endif

--- a/core/iwasm/fast-jit/fe/jit_emit_compare.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_compare.c
@@ -187,7 +187,7 @@ jit_compile_op_compare_float_point(JitCompContext *cc, FloatCond cond,
             case FLOAT_LT:
             {
                 GEN_INSN(CMP, cc->cmp_reg, rhs, lhs);
-                GEN_INSN(SELECTLTS, res, cc->cmp_reg, const_one, const_zero);
+                GEN_INSN(SELECTGTS, res, cc->cmp_reg, const_one, const_zero);
                 break;
             }
             case FLOAT_GT:
@@ -199,7 +199,7 @@ jit_compile_op_compare_float_point(JitCompContext *cc, FloatCond cond,
             case FLOAT_LE:
             {
                 GEN_INSN(CMP, cc->cmp_reg, rhs, lhs);
-                GEN_INSN(SELECTLES, res, cc->cmp_reg, const_one, const_zero);
+                GEN_INSN(SELECTGES, res, cc->cmp_reg, const_one, const_zero);
                 break;
             }
             case FLOAT_GE:

--- a/core/iwasm/fast-jit/fe/jit_emit_conversion.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_conversion.c
@@ -63,8 +63,8 @@ jit_compile_op_i32_trunc_f32(JitCompContext *cc, bool sign, bool saturating)
         }
 
         /* If value is out of integer range, throw exception */
-        GEN_INSN(CMP, cc->cmp_reg, value, min_valid_float);
-        if (!jit_emit_exception(cc, EXCE_INTEGER_OVERFLOW, JIT_OP_BLES,
+        GEN_INSN(CMP, cc->cmp_reg, min_valid_float, value);
+        if (!jit_emit_exception(cc, EXCE_INTEGER_OVERFLOW, JIT_OP_BGES,
                                 cc->cmp_reg, NULL)) {
             goto fail;
         }
@@ -123,8 +123,8 @@ jit_compile_op_i32_trunc_f64(JitCompContext *cc, bool sign, bool saturating)
         }
 
         /* If value is out of integer range, throw exception */
-        GEN_INSN(CMP, cc->cmp_reg, value, min_valid_double);
-        if (!jit_emit_exception(cc, EXCE_INTEGER_OVERFLOW, JIT_OP_BLES,
+        GEN_INSN(CMP, cc->cmp_reg, min_valid_double, value);
+        if (!jit_emit_exception(cc, EXCE_INTEGER_OVERFLOW, JIT_OP_BGES,
                                 cc->cmp_reg, NULL)) {
             goto fail;
         }

--- a/core/iwasm/fast-jit/fe/jit_emit_variable.c
+++ b/core/iwasm/fast-jit/fe/jit_emit_variable.c
@@ -165,7 +165,16 @@ fail:
 static uint8
 get_global_type(const WASMModule *module, uint32 global_idx)
 {
-    return module->globals[global_idx].type;
+    if (global_idx < module->import_global_count) {
+        const WASMGlobalImport *import_global =
+            &((module->import_globals + global_idx)->u.global);
+        return import_global->type;
+    }
+    else {
+        const WASMGlobal *global =
+            module->globals + (global_idx - module->import_global_count);
+        return global->type;
+    }
 }
 
 static uint32
@@ -177,7 +186,8 @@ get_global_data_offset(const WASMModule *module, uint32 global_idx)
         return import_global->data_offset;
     }
     else {
-        const WASMGlobal *global = module->globals + global_idx;
+        const WASMGlobal *global =
+            module->globals + (global_idx - module->import_global_count);
         return global->data_offset;
     }
 }

--- a/core/iwasm/fast-jit/jit_dump.c
+++ b/core/iwasm/fast-jit/jit_dump.c
@@ -332,6 +332,12 @@ jit_pass_dump(JitCompContext *cc)
     const char *pass_name =
         pass_no > 0 ? jit_compiler_get_pass_name(passes[pass_no - 1]) : "NULL";
 
+#if defined(BUILD_TARGET_X86_64) || defined(BUILD_TARGET_AMD_64)
+    if (!strcmp(pass_name, "lower_cg"))
+        /* Ignore lower codegen pass as it does nothing in x86-64 */
+        return true;
+#endif
+
     os_printf("JIT.COMPILER.DUMP: PASS_NO=%d PREV_PASS=%s\n\n", pass_no,
               pass_name);
     jit_dump_cc(cc);

--- a/core/iwasm/fast-jit/jit_frontend.c
+++ b/core/iwasm/fast-jit/jit_frontend.c
@@ -755,9 +755,11 @@ init_func_translation(JitCompContext *cc)
 
     cc->jit_frame = jit_frame;
     cc->cur_basic_block = jit_cc_entry_basic_block(cc);
-    cc->total_frame_size = wasm_interp_interp_frame_size(total_cell_num);
-    cc->spill_cache_offset = (uint32)offsetof(WASMInterpFrame, spill_cache);
-    cc->spill_cache_size = (uint32)sizeof(uint32) * FAST_JIT_SPILL_CACHE_SIZE;
+    cc->spill_cache_offset = wasm_interp_interp_frame_size(total_cell_num);
+    /* Set spill cache size according to max local cell num, max stack cell
+       num and virtual fixed register num */
+    cc->spill_cache_size = (max_locals + max_stacks) * 4 + sizeof(void *) * 4;
+    cc->total_frame_size = cc->spill_cache_offset + cc->spill_cache_size;
     cc->jitted_return_address_offset =
         offsetof(WASMInterpFrame, jitted_return_addr);
     cc->cur_basic_block = jit_cc_entry_basic_block(cc);
@@ -838,7 +840,7 @@ free_block_memory(JitBlock *block)
     jit_free(block);
 }
 
-static JitBlock *
+static JitBasicBlock *
 create_func_block(JitCompContext *cc)
 {
     JitBlock *jit_block;
@@ -883,7 +885,7 @@ create_func_block(JitCompContext *cc)
     jit_block_stack_push(&cc->block_stack, jit_block);
     cc->cur_basic_block = jit_block->basic_block_entry;
 
-    return jit_block;
+    return jit_block->basic_block_entry;
 
 fail:
     free_block_memory(jit_block);
@@ -2086,13 +2088,13 @@ JitBasicBlock *
 jit_frontend_translate_func(JitCompContext *cc)
 {
     JitFrame *jit_frame;
-    JitBlock *jit_block;
+    JitBasicBlock *basic_block_entry;
 
     if (!(jit_frame = init_func_translation(cc))) {
         return NULL;
     }
 
-    if (!(jit_block = create_func_block(cc))) {
+    if (!(basic_block_entry = create_func_block(cc))) {
         return NULL;
     }
 
@@ -2100,7 +2102,7 @@ jit_frontend_translate_func(JitCompContext *cc)
         return NULL;
     }
 
-    return jit_block->basic_block_entry;
+    return basic_block_entry;
 }
 
 #if 0

--- a/core/iwasm/interpreter/wasm_interp.h
+++ b/core/iwasm/interpreter/wasm_interp.h
@@ -28,7 +28,6 @@ typedef struct WASMInterpFrame {
 
 #if WASM_ENABLE_FAST_JIT != 0
     uint8 *jitted_return_addr;
-    uint32 spill_cache[FAST_JIT_SPILL_CACHE_SIZE];
 #endif
 
 #if WASM_ENABLE_PERF_PROFILING != 0
@@ -52,12 +51,13 @@ typedef struct WASMInterpFrame {
     WASMBranchBlock *csp_boundary;
     WASMBranchBlock *csp;
 
-    /* Frame data, the layout is:
-       lp: param_cell_count + local_cell_count
-       sp_bottom to sp_boundary: stack of data
-       csp_bottom to csp_boundary: stack of block
-       ref to frame end: data types of local vairables and stack data
-       */
+    /**
+     * Frame data, the layout is:
+     *  lp: parameters and local variables
+     *  sp_bottom to sp_boundary: wasm operand stack
+     *  csp_bottom to csp_boundary: wasm label stack
+     *  jit spill cache: only available for fast jit
+     */
     uint32 lp[1];
 #endif
 } WASMInterpFrame;

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1509,8 +1509,8 @@ wasm_instantiate(WASMModule *module, bool is_sub_inst, uint32 stack_size,
     if (stack_size == 0)
         stack_size = DEFAULT_WASM_STACK_SIZE;
 #if WASM_ENABLE_SPEC_TEST != 0
-    if (stack_size < 100 * 1024)
-        stack_size = 100 * 1024;
+    if (stack_size < 64 * 1024)
+        stack_size = 64 * 1024;
 #endif
     module_inst->default_wasm_stack_size = stack_size;
 


### PR DESCRIPTION
Move jit spill cache to the end of interp frame to reduce footprint
Fix codegen compare float issue: should not overwritten the source registers
Fix float to int conversion check integer overflow issue
Unify the float compare
Fix get_global issue