### PR TITLE
Unify AOT/interp module inst's tables member (#1503)

### DIFF
--- a/core/iwasm/aot/aot_runtime.h
+++ b/core/iwasm/aot/aot_runtime.h
@@ -559,9 +559,6 @@ aot_table_grow(AOTModuleInstance *module_inst, uint32 tbl_idx,
                uint32 inc_entries, uint32 init_val);
 #endif
 
-AOTTableInstance *
-aot_next_tbl_inst(const AOTTableInstance *tbl_inst);
-
 bool
 aot_alloc_frame(WASMExecEnv *exec_env, uint32 func_index);
 

--- a/core/iwasm/common/wasm_c_api.c
+++ b/core/iwasm/common/wasm_c_api.c
@@ -3372,8 +3372,7 @@ wasm_table_get(const wasm_table_t *table, wasm_table_size_t index)
 #if WASM_ENABLE_AOT != 0
     if (table->inst_comm_rt->module_type == Wasm_Module_AoT) {
         AOTModuleInstance *inst_aot = (AOTModuleInstance *)table->inst_comm_rt;
-        AOTTableInstance *table_aot =
-            (AOTTableInstance *)inst_aot->tables + table->table_idx_rt;
+        AOTTableInstance *table_aot = inst_aot->tables[table->table_idx_rt];
         if (index >= table_aot->cur_size) {
             return NULL;
         }
@@ -3447,8 +3446,7 @@ wasm_table_set(wasm_table_t *table, wasm_table_size_t index,
     if (table->inst_comm_rt->module_type == Wasm_Module_AoT) {
         AOTModuleInstance *inst_aot = (AOTModuleInstance *)table->inst_comm_rt;
         AOTModule *module_aot = (AOTModule *)inst_aot->module;
-        AOTTableInstance *table_aot =
-            (AOTTableInstance *)inst_aot->tables + table->table_idx_rt;
+        AOTTableInstance *table_aot = inst_aot->tables[table->table_idx_rt];
 
         if (index >= table_aot->cur_size) {
             return false;

--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -4493,8 +4493,7 @@ aot_mark_all_externrefs(AOTModuleInstance *module_inst)
     const AOTModule *module = (AOTModule *)module_inst->module;
     const AOTTable *table = module->tables;
     const AOTGlobal *global = module->globals;
-    const AOTTableInstance *table_inst =
-        (AOTTableInstance *)module_inst->tables;
+    const AOTTableInstance *table_inst;
 
     for (i = 0; i < module->global_count; i++, global++) {
         if (global->type == VALUE_TYPE_EXTERNREF) {
@@ -4503,9 +4502,8 @@ aot_mark_all_externrefs(AOTModuleInstance *module_inst)
         }
     }
 
-    for (i = 0; i < module->table_count;
-         i++, table_inst = aot_next_tbl_inst(table_inst)) {
-
+    for (i = 0; i < module->table_count; i++) {
+        table_inst = module_inst->tables[i];
         if ((table + i)->elem_type == VALUE_TYPE_EXTERNREF) {
             while (j < table_inst->cur_size) {
                 mark_externref(table_inst->elems[j++]);


### PR DESCRIPTION
Make AOT module instance's tables member same as interpreter module instance's, so as to unify this field and prepare for the API unifying.