### PR TITLE
Add memory watchpoint support for source debugger (#1762)

### DIFF
--- a/core/iwasm/libraries/debug-engine/debug_engine.h
+++ b/core/iwasm/libraries/debug-engine/debug_engine.h
@@ -36,6 +36,12 @@ typedef struct WASMDebugBreakPoint {
     uint64 orignal_data;
 } WASMDebugBreakPoint;
 
+typedef struct WASMDebugWatchPoint {
+    bh_list_link next;
+    uint64 addr;
+    uint64 length;
+} WASMDebugWatchPoint;
+
 typedef enum debug_state_t {
     /* Debugger state conversion sequence:
      *   DBG_LAUNCHING ---> APP_STOPPED <---> APP_RUNNING
@@ -56,6 +62,8 @@ struct WASMDebugInstance {
     struct WASMDebugInstance *next;
     WASMDebugControlThread *control_thread;
     bh_list break_point_list;
+    bh_list watch_point_list_read;
+    bh_list watch_point_list_write;
     WASMCluster *cluster;
     uint32 id;
     korp_tid current_tid;
@@ -183,6 +191,22 @@ wasm_debug_instance_add_breakpoint(WASMDebugInstance *instance, uint64 addr,
 bool
 wasm_debug_instance_remove_breakpoint(WASMDebugInstance *instance, uint64 addr,
                                       uint64 length);
+
+bool
+wasm_debug_instance_watchpoint_write_add(WASMDebugInstance *instance,
+                                         uint64 addr, uint64 length);
+
+bool
+wasm_debug_instance_watchpoint_write_remove(WASMDebugInstance *instance,
+                                            uint64 addr, uint64 length);
+
+bool
+wasm_debug_instance_watchpoint_read_add(WASMDebugInstance *instance,
+                                        uint64 addr, uint64 length);
+
+bool
+wasm_debug_instance_watchpoint_read_remove(WASMDebugInstance *instance,
+                                           uint64 addr, uint64 length);
 
 bool
 wasm_debug_instance_on_failure(WASMDebugInstance *instance);


### PR DESCRIPTION
Allow to add watchpoints to variables for source debugging. For instance: `breakpoint set variable var`
will pause WAMR execution when the address at var is written to. Can also set read/write watchpoints by passing r/w flags. This will pause execution when the address at var is read:
`watchpoint set variable -w read var`

Add two linked lists for read/write watchpoints. When the debug message handler receives a watchpoint request, it adds/removes to one/both of these lists. In the interpreter, when an address is read or stored to, check whether the address is in these lists. If so, throw a sigtrap and suspend the process.