### PR TITLE
Restore the app heap corrupted prompt (#1885)

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -5128,7 +5128,7 @@ void
 wasm_runtime_show_app_heap_corrupted_prompt()
 {
     LOG_ERROR("Error: app heap is corrupted, if the wasm file "
-              "is compiled by wasi-sdk-16.0 or higher version, "
+              "is compiled by wasi-sdk-12.0 or higher version, "
               "please add -Wl,--export=malloc -Wl,--export=free "
               "to export malloc and free functions. If it is "
               "compiled by asc, please add --exportRuntime to "


### PR DESCRIPTION
Change `wasi-sdk-16.0` to `wasi-sdk-12.0` in wasm_runtime_show_app_heap_corrupted_prompt, which was mis-modified by previous commit.