### PR TITLE
Fix compilation error on Android platform (#2594)

### DIFF
--- a/core/shared/platform/android/platform_internal.h
+++ b/core/shared/platform/android/platform_internal.h
@@ -139,15 +139,11 @@ seekdir(DIR *__dir, long __location);
 
 #endif
 
-#if __ANDROID_API__ < 24
-
 ssize_t
 preadv(int __fd, const struct iovec *__iov, int __count, off_t __offset);
 
 ssize_t
 pwritev(int __fd, const struct iovec *__iov, int __count, off_t __offset);
-
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The CI might use clang-17 to build iwasm for Android platform and it may report compilation error:
https://github.com/bytecodealliance/wasm-micro-runtime/actions/runs/6308980430/job/17128073777

/home/runner/work/wasm-micro-runtime/wasm-micro-runtime/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/blocking_op.c:45:19: error: call to undeclared function 'preadv'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    ssize_t ret = preadv(fd, iov, iovcnt, offset);
                  ^

Explicitly declare preadv and pwritev in android platform header file to resolve it.